### PR TITLE
fix(cron): make FCM app lifecycle async-safe

### DIFF
--- a/app/cron.py
+++ b/app/cron.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import uuid
 from asyncio import Task
 from datetime import datetime, timedelta
 from typing import Any
@@ -8,7 +7,7 @@ from zoneinfo import ZoneInfo
 
 from arq import cron
 from arq.worker import Worker, create_worker
-from firebase_admin import credentials, delete_app, initialize_app, messaging
+from firebase_admin import App, credentials, delete_app, get_app, initialize_app, messaging
 from sentry_sdk import get_current_scope
 
 from app import schemas
@@ -16,6 +15,39 @@ from app import constants
 from app.constants import MatchStatus
 from app.core.config import settings
 from app.services import events, matches, news, rankings, standings
+
+_FCM_APP_NAME = "vlrgg-fcm"
+
+
+def _get_fcm_app() -> App:
+    try:
+        return get_app(_FCM_APP_NAME)
+    except ValueError:
+        try:
+            credential = credentials.Certificate(settings.GOOGLE_APPLICATION_CREDENTIALS)
+            return initialize_app(
+                name=_FCM_APP_NAME,
+                credential=credential,
+            )
+        except ValueError as exc:
+            try:
+                return get_app(_FCM_APP_NAME)
+            except ValueError:
+                raise exc
+
+
+async def _close_fcm_app() -> None:
+    try:
+        app = get_app(_FCM_APP_NAME)
+    except ValueError:
+        return
+
+    # firebase_admin 7.3.0 closes an async HTTP client via asyncio.run(), so
+    # cleanup must happen off the worker's event loop.
+    try:
+        await asyncio.to_thread(delete_app, app)
+    except Exception:
+        logging.exception("Failed to delete Firebase app during shutdown: %s", _FCM_APP_NAME)
 
 
 async def fcm_notification_cron(ctx: dict) -> None:
@@ -79,13 +111,8 @@ async def fcm_notification_cron(ctx: dict) -> None:
     if not messages:
         return
 
-    app_name = ctx.get("job_id", uuid.uuid4())
-    app = initialize_app(
-        name=app_name,
-        credential=credentials.Certificate(settings.GOOGLE_APPLICATION_CREDENTIALS),
-    )
-    messaging.send_each(messages=messages, app=app)
-    delete_app(app)
+    app = _get_fcm_app()
+    await messaging.send_each_async(messages=messages, dry_run=False, app=app)
     logging.info("Sent notification")
 
 
@@ -200,6 +227,7 @@ class ArqWorker:
     async def stop(self) -> None:
         if self.worker:
             await self.worker.close()
+        await _close_fcm_app()
 
 
 arq_worker = ArqWorker()

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app import cron
+from app.constants import MatchStatus
+
+
+@pytest.mark.asyncio
+async def test_fcm_notification_cron_uses_async_send_with_reused_app():
+    current_time = datetime.now(tz=ZoneInfo(cron.settings.TIMEZONE))
+    upcoming_match = SimpleNamespace(
+        id="123",
+        status=MatchStatus.UPCOMING,
+        time=current_time + timedelta(minutes=10),
+        team1=SimpleNamespace(name="Team A"),
+        team2=SimpleNamespace(name="Team B"),
+    )
+    match_details = SimpleNamespace(
+        teams=[SimpleNamespace(id="1"), SimpleNamespace(id="2")],
+        event=SimpleNamespace(id="99"),
+        videos=SimpleNamespace(streams=[]),
+    )
+    app = object()
+
+    with (
+        patch("app.cron.matches.get_upcoming_matches", AsyncMock(return_value=[upcoming_match])),
+        patch("app.cron.matches.match_by_id", AsyncMock(return_value=match_details)),
+        patch("app.cron._get_fcm_app", return_value=app) as get_fcm_app,
+        patch("app.cron.messaging.send_each_async", AsyncMock()) as send_each_async,
+    ):
+        await cron.fcm_notification_cron({"redis": AsyncMock()})
+
+    get_fcm_app.assert_called_once_with()
+    send_each_async.assert_awaited_once()
+    _, kwargs = send_each_async.await_args
+    assert kwargs["app"] is app
+    assert kwargs["dry_run"] is False
+    assert len(kwargs["messages"]) == 1
+    assert kwargs["messages"][0].data["title"] == "Team A vs Team B"
+    assert kwargs["messages"][0].data["match_id"] == "123"
+
+
+@pytest.mark.asyncio
+async def test_close_fcm_app_uses_worker_safe_cleanup():
+    app = object()
+
+    with (
+        patch("app.cron.get_app", return_value=app),
+        patch("app.cron.asyncio.to_thread", AsyncMock()) as to_thread,
+    ):
+        await cron._close_fcm_app()
+
+    to_thread.assert_awaited_once_with(cron.delete_app, app)
+
+
+def test_get_fcm_app_returns_existing_app_without_initializing():
+    app = object()
+
+    with (
+        patch("app.cron.get_app", return_value=app) as get_app,
+        patch("app.cron.initialize_app") as initialize_app,
+    ):
+        result = cron._get_fcm_app()
+
+    assert result is app
+    get_app.assert_called_once_with("vlrgg-fcm")
+    initialize_app.assert_not_called()
+
+
+def test_get_fcm_app_returns_existing_app_if_concurrent_init_wins():
+    app = object()
+    credential = object()
+    get_app_calls = 0
+
+    def get_app_side_effect(*_args, **_kwargs):
+        nonlocal get_app_calls
+        get_app_calls += 1
+        if get_app_calls == 1:
+            raise ValueError
+        return app
+
+    with (
+        patch("app.cron.get_app", side_effect=get_app_side_effect) as get_app,
+        patch("app.cron.credentials.Certificate", return_value=credential),
+        patch("app.cron.initialize_app", side_effect=ValueError()) as initialize_app,
+    ):
+        result = cron._get_fcm_app()
+
+    assert result is app
+    initialize_app.assert_called_once_with(
+        name="vlrgg-fcm",
+        credential=credential,
+    )
+    assert get_app.call_count == 2
+
+
+def test_get_fcm_app_initializes_when_missing():
+    app = object()
+    credential = object()
+
+    with (
+        patch("app.cron.get_app", side_effect=[ValueError(), ValueError()]) as get_app,
+        patch("app.cron.credentials.Certificate", return_value=credential),
+        patch("app.cron.initialize_app", return_value=app) as initialize_app,
+    ):
+        result = cron._get_fcm_app()
+
+    assert result is app
+    get_app.assert_called_once_with("vlrgg-fcm")
+    initialize_app.assert_called_once_with(
+        name="vlrgg-fcm",
+        credential=credential,
+    )
+
+
+def test_get_fcm_app_reraises_original_init_error_when_no_app_exists():
+    credential = object()
+    init_error = ValueError("invalid service account")
+
+    with (
+        patch("app.cron.get_app", side_effect=[ValueError(), ValueError()]),
+        patch("app.cron.credentials.Certificate", return_value=credential),
+        patch("app.cron.initialize_app", side_effect=init_error),
+    ):
+        with pytest.raises(ValueError, match="invalid service account"):
+            cron._get_fcm_app()
+
+
+@pytest.mark.asyncio
+async def test_close_fcm_app_skips_missing_app():
+    with (
+        patch("app.cron.get_app", side_effect=ValueError),
+        patch("app.cron.asyncio.to_thread", AsyncMock()) as to_thread,
+    ):
+        await cron._close_fcm_app()
+
+    to_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_close_fcm_app_logs_and_continues_on_cleanup_failure():
+    app = object()
+
+    with (
+        patch("app.cron.get_app", return_value=app),
+        patch("app.cron.asyncio.to_thread", AsyncMock(side_effect=RuntimeError("boom"))) as to_thread,
+        patch("app.cron.logging.exception") as log_exception,
+    ):
+        await cron._close_fcm_app()
+
+    to_thread.assert_awaited_once_with(cron.delete_app, app)
+    log_exception.assert_called_once_with("Failed to delete Firebase app during shutdown: %s", "vlrgg-fcm")


### PR DESCRIPTION
## Summary
- reuse a single named Firebase app for the FCM cron instead of creating and deleting one per run
- send notifications with `messaging.send_each_async(..., dry_run=False)` on the existing ARQ event loop
- keep app initialization lock-free but race-tolerant so concurrent calls can recover cleanly without event-loop-bound state
- clean up the Firebase app on worker shutdown via `asyncio.to_thread(delete_app, app)` and log cleanup failures without breaking shutdown
- add targeted cron tests covering app reuse, initialization, preserved init failures, and shutdown cleanup behavior

## Root cause
`firebase_admin` 7.3.0 closes its messaging async client with `asyncio.run(...)` during `delete_app()`. The FCM cron runs inside ARQ's active event loop, so deleting the app at the end of each async job raises `RuntimeError: asyncio.run() cannot be called from a running event loop`.

## Testing
- `.venv/bin/pytest -q`
