### PR TITLE
Fix null scores on completed match details

### DIFF
--- a/app/services/matches.py
+++ b/app/services/matches.py
@@ -83,8 +83,10 @@ async def get_team_data(data: ResultSet, client: Redis | None) -> list[dict]:
         None,
         None,
     ]  # Default to None for both teams - required for upcoming matches
+    # The score lives in a `sp-hide` div alongside an `sp-alt` sibling holding "vs.", so it must be
+    # selected directly rather than read off the surrounding `match-header-vs-score` container.
     if (match_data := match_header.find_all("div", class_="match-header-vs-score")) and (
-        match_data := match_data[0].find_all("div", class_="js-spoiler")
+        match_data := match_data[0].find_all("div", class_="sp-hide")
     ):
         match_score = (clean_string(match_data[0].get_text())).split(":")
 

--- a/tests/fixtures/match_header_completed.html
+++ b/tests/fixtures/match_header_completed.html
@@ -1,0 +1,74 @@
+<html><body><div class="wf-card mod-color mod-bg-after-striped_redyellow match-header">
+<div class="match-header-super">
+<div>
+<a class="match-header-event" href="/event/2283/valorant-champions-2025/playoffs">
+<img src="//owcdn.net/img/63067806d167d.png" style="height: 32px; width: 32px; margin-right: 6px;"/>
+<div>
+<div style="font-weight: 700;">
+						Valorant Champions 2025					</div>
+<div class="match-header-event-series">
+						Playoffs: 
+						Grand Final					</div>
+</div>
+</a>
+</div>
+<div style="text-align: right;">
+<div class="match-header-date">
+<div class="moment-tz-convert" data-moment-format="MMMM D, YYYY" data-utc-ts="2025-10-05 07:00:00" style="white-space: nowrap;">
+					October 5, 2025				</div>
+<div class="moment-tz-convert" data-moment-format="h:mm A z" data-utc-ts="2025-10-05 07:00:00" style="font-size: 12px;">
+
+							
+						4:30 PM IST					</div>
+<div style="margin-top: 4px;">
+<div style="font-style: italic;">
+								Patch 11.05							</div>
+</div>
+</div>
+</div>
+</div>
+<div class="match-header-vs">
+<a class="match-header-link wf-link-hover mod-1" href="/team/1034/nrg">
+<div class="match-header-link-name mod-1">
+<div class="wf-title-med mod-single">
+											NRG									</div>
+<div class="match-header-link-name-elo">
+</div>
+</div>
+<img alt="NRG team logo" src="//owcdn.net/img/6610f026c1a9e.png"/>
+</a>
+<div class="match-header-vs-score">
+<div class="match-header-vs-note">
+
+									final
+							</div>
+<div class="match-header-vs-score">
+<div class="sp-hide">
+<span class="match-header-vs-score-winner">
+							3						</span>
+<span class="match-header-vs-score-colon">
+							:
+						</span>
+<span class="match-header-vs-score-loser">
+							2						</span>
+</div>
+<div class="sp-alt" style="font-size: 24px; padding-top: 2px; padding-bottom: 6px; margin-right: -4px;">
+						vs.
+					</div>
+</div>
+<div class="match-header-vs-note">
+									Bo5							</div>
+</div>
+<a class="match-header-link wf-link-hover mod-2" href="/team/2593/fnatic">
+<img alt="FNATIC team logo" src="//owcdn.net/img/62a40cc2b5e29.png"/>
+<div class="match-header-link-name mod-2">
+<div class="wf-title-med mod-single">
+											FNATIC									</div>
+<div class="match-header-link-name-elo">
+</div>
+</div>
+</a>
+</div>
+<div class="match-header-note">
+			NRG ban Haven; NRG ban Bind; NRG pick Corrode; FNC pick Lotus; NRG pick Abyss; FNC pick Ascent; Sunset remains		</div>
+</div></body></html>

--- a/tests/golden/test_live_golden/match_12345.yml
+++ b/tests/golden/test_live_golden/match_12345.yml
@@ -302,11 +302,11 @@ teams:
 - id: '556'
   img: https://www.vlr.gg/img/vlr/tmp/vlr.png
   name: keepYOURskill
-  score: null
+  score: 1
 - id: '3333'
   img: https://www.vlr.gg/img/vlr/tmp/vlr.png
   name: IMBAPEEK
-  score: null
+  score: 0
 videos:
   streams: []
   vods: []

--- a/tests/golden/test_live_golden/match_542272.yml
+++ b/tests/golden/test_live_golden/match_542272.yml
@@ -1433,11 +1433,11 @@ teams:
 - id: '1034'
   img: https://owcdn.net/img/6610f026c1a9e.png
   name: NRG
-  score: null
+  score: 3
 - id: '2593'
   img: https://owcdn.net/img/62a40cc2b5e29.png
   name: FNATIC
-  score: null
+  score: 2
 videos:
   streams:
   - name: Valorant

--- a/tests/golden/test_live_golden/match_673178.yml
+++ b/tests/golden/test_live_golden/match_673178.yml
@@ -547,11 +547,11 @@ teams:
 - id: '104'
   img: https://owcdn.net/img/62a4139de7f7e.png
   name: REJECT
-  score: null
+  score: 2
 - id: '16244'
   img: https://www.vlr.gg/img/vlr/tmp/vlr.png
   name: PARON
-  score: null
+  score: 0
 videos:
   streams: []
   vods: []

--- a/tests/golden/test_live_golden/match_706763.yml
+++ b/tests/golden/test_live_golden/match_706763.yml
@@ -850,11 +850,11 @@ teams:
 - id: '1034'
   img: https://owcdn.net/img/6610f026c1a9e.png
   name: NRG
-  score: null
+  score: 2
 - id: '8877'
   img: https://owcdn.net/img/627403a0d9e48.png
   name: Karmine Corp
-  score: null
+  score: 1
 videos:
   streams:
   - name: EWC STC EN 1

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -9,6 +9,39 @@ from app.constants import MAX_PAGINATION_PAGES
 from app.services import matches
 
 
+@pytest.mark.asyncio
+async def test_get_team_data_parses_completed_match_score():
+    """A completed match must report each team's score from the header."""
+    html = (Path(__file__).parent / "fixtures" / "match_header_completed.html").read_text()
+    header = BeautifulSoup(html, "lxml").find_all("div", class_="match-header")
+
+    result = await matches.get_team_data(header, None)
+
+    assert [team["name"] for team in result] == ["NRG", "FNATIC"]
+    assert [team["score"] for team in result] == ["3", "2"]
+
+
+@pytest.mark.asyncio
+async def test_get_team_data_leaves_score_none_for_upcoming_match():
+    """An upcoming match has no score element, so both scores stay None."""
+    html = """
+    <div class="match-header">
+      <a class="match-header-link" href="/team/1/alpha"><img src="/img/a.png"/></a>
+      <div class="wf-title-med">Alpha</div>
+      <a class="match-header-link" href="/team/2/beta"><img src="/img/b.png"/></a>
+      <div class="wf-title-med">Beta</div>
+      <div class="match-header-vs-score">
+        <div class="match-header-vs-note">upcoming</div>
+      </div>
+    </div>
+    """
+    header = BeautifulSoup(html, "lxml").find_all("div", class_="match-header")
+
+    result = await matches.get_team_data(header, None)
+
+    assert [team["score"] for team in result] == [None, None]
+
+
 def test_parse_div_based_overview_scoreboard():
     html = """
     <div class="vm-stats-game">


### PR DESCRIPTION
## The bug

VLR renamed the match header's score container from `js-spoiler` to `sp-hide`. The selector in `app/services/matches.py` matched nothing, the `and`-chain fell through, and `match_score` kept its `[None, None]` default — the value meant for *upcoming* matches. **Every completed match served by `/match/{id}` has been returning `score: null` for both teams.**

Reported live: `/match/698884` (Gen.G vs ZETA DIVISION, VCT 2026 Pacific Stage 2) served nulls for a match that finished 2:0.

Only the detail endpoint is affected — the match list parses scores via `parse_score` off the cards and kept reporting correctly, which is why this went unnoticed.

## The fix

One selector. The score sits in a `sp-hide` div beside an `sp-alt` sibling holding "vs.", so it must be selected directly; reading the surrounding `match-header-vs-score` container yields `"3:2vs."`.

Verified live after the fix:

| Match | Before | After |
|---|---|---|
| 698884 (Gen.G vs ZETA) | `null` / `null` | `2` / `0` |
| 542272 (NRG vs FNATIC) | `null` / `null` | `3` / `2` |
| 673178 (REJECT vs PARON) | `null` / `null` | `2` / `0` |
| 706763 (NRG vs Karmine Corp) | `null` / `null` | `2` / `1` |

## Tests

Two unit tests over a new 2.4KB fixture trimmed from the live page with the current markup: one pins the parsed score, one pins the `None` default for upcoming matches so the fix can't regress into reading the parent container. Both fail against the old selector (`[None, None] != ['3', '2']`).

Every existing fixture predates the rename, so no offline test covered this path — that gap is what let it ship.

## Baselines

The four match baselines are restored to real scores. They were bulk-regenerated in b5df908 while the parser was already broken, which recorded the nulls as the expected values and buried the evidence.

> [!NOTE]
> `team_1120` and `player_3520` live goldens fail on master from unrelated match churn (a team page always shows its latest matches, so page one shifts whenever they play). Not gated by CI (`-m "not live_golden"`) and addressed separately in the test-structure work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)