### PR TITLE
Preserve article structure and add embedded video players

### DIFF
--- a/app/api/media.py
+++ b/app/api/media.py
@@ -1,0 +1,46 @@
+"""Public, fixed-provider embed pages for native mobile WebViews."""
+
+from html import escape
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from app.services.news_video import valid_media_id
+
+router = APIRouter()
+
+
+@router.get("/media/{provider}/{media_id}", response_class=HTMLResponse)
+async def media_player(request: Request, provider: str, media_id: str) -> HTMLResponse:
+    if not valid_media_id(provider, media_id):
+        raise HTTPException(status_code=404, detail="Unsupported video")
+    if provider == "youtube":
+        query = urlencode({"origin": str(request.base_url).rstrip("/"), "playsinline": "1", "autoplay": "0"})
+        source = f"https://www.youtube.com/embed/{media_id}?{query}"
+        title = "YouTube video player"
+        frame_origin = "https://www.youtube.com"
+        min_width, min_height = 200, 200
+    else:
+        query = urlencode({"clip": media_id, "parent": request.url.hostname, "autoplay": "false"})
+        source = f"https://clips.twitch.tv/embed?{query}"
+        title = "Twitch clip player"
+        frame_origin = "https://clips.twitch.tv"
+        min_width, min_height = 400, 300
+    html = f'''<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{title}</title>
+<style>html,body{{margin:0;width:100%;height:100%;background:#000}}
+iframe{{display:block;border:0;width:100%;height:100%;min-width:{min_width}px;min-height:{min_height}px}}</style>
+</head><body><iframe src="{escape(source, quote=True)}" title="{title}"
+allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe></body></html>'''
+    return HTMLResponse(
+        html,
+        headers={
+            "Content-Security-Policy": f"default-src 'none'; style-src 'unsafe-inline'; frame-src {frame_origin}; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+            "Referrer-Policy": "strict-origin-when-cross-origin",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/app/constants.py
+++ b/app/constants.py
@@ -57,6 +57,13 @@ class EventStatus(str, Enum):
     UNKNOWN = "unknown"
 
 
+class NewsVideoProvider(str, Enum):
+    """Providers supported by hosted news video players."""
+
+    YOUTUBE = "youtube"
+    TWITCH = "twitch"
+
+
 REGION_NAME_MAPPING = {
     # "gc": "Game Changers",
     "la-s": "Latin America South",

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
+from app.api.media import router as media_router
 from app.api import deps
 from app.api.v1.api import router
 from app.api.v1.endpoints.internal import router as internal_router
@@ -119,6 +120,8 @@ async def add_server_name_header(request: Request, call_next: Callable) -> Respo
     response.headers["X-Server"] = _HOSTNAME
     return response
 
+
+app.include_router(media_router)
 
 if settings.API_KEYS:
     print("Got API keys", settings.API_KEYS.keys())

--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,6 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 
-from app.api.media import router as media_router
 from app.api import deps
 from app.api.v1.api import router
 from app.api.v1.endpoints.internal import router as internal_router
@@ -26,6 +25,7 @@ from app.core import connections
 from app.core.config import settings
 from app.cron import arq_worker
 from app.utils import before_send
+from app.web.media import router as media_router
 
 # Git SHA for Sentry release tracking
 _RELEASE = os.environ.get("GIT_SHA")

--- a/app/schemas/news.py
+++ b/app/schemas/news.py
@@ -1,6 +1,9 @@
-from datetime import datetime
+from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
 
 
 # Response for `GET /api/v1/news`
@@ -12,11 +15,33 @@ class NewsItem(BaseModel):
     author: str
 
 
+class NewsTextRun(BaseModel):
+    text: str
+    url: str | None = None
+    bold: bool = False
+    italic: bool = False
+
+
+NewsBlockType = Literal["paragraph", "heading", "blockquote", "list", "list_item", "image", "video", "caption"]
+
+
+class NewsBlock(BaseModel):
+    type: NewsBlockType
+    runs: list[NewsTextRun] = Field(default_factory=list)
+    children: list[NewsBlock] = Field(default_factory=list)
+    level: int | None = None
+    ordered: bool = False
+    start: int = 1
+    url: str | None = None
+    alt: str = ""
+
+
 # Response for `GET /api/v1/news/{id}`
 class NewsArticle(BaseModel):
     id: str
     title: str
     content: str
+    blocks: list[NewsBlock] = Field(default_factory=list)
     links: list[dict[str, str]]
     images: list[str]
     videos: list[str]

--- a/app/schemas/news.py
+++ b/app/schemas/news.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
 from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+from app.constants import NewsVideoProvider
 
 
 # Response for `GET /api/v1/news`
@@ -26,13 +26,18 @@ NewsBlockType = Literal["paragraph", "heading", "blockquote", "list", "list_item
 
 
 class NewsVideoPlayer(BaseModel):
-    provider: Literal["youtube", "twitch"]
+    provider: NewsVideoProvider
     media_id: str
     player_url: str
     external_url: str
 
 
 class NewsBlock(BaseModel):
+    """A supported article block, optionally containing nested or media content.
+
+    For media, ``url`` is the source while ``link_url`` is its wrapping anchor.
+    """
+
     type: NewsBlockType
     runs: list[NewsTextRun] = Field(default_factory=list)
     children: list[NewsBlock] = Field(default_factory=list)
@@ -40,6 +45,7 @@ class NewsBlock(BaseModel):
     ordered: bool = False
     start: int = 1
     url: str | None = None
+    link_url: str | None = None
     alt: str = ""
     player: NewsVideoPlayer | None = None
 

--- a/app/schemas/news.py
+++ b/app/schemas/news.py
@@ -25,6 +25,13 @@ class NewsTextRun(BaseModel):
 NewsBlockType = Literal["paragraph", "heading", "blockquote", "list", "list_item", "image", "video", "caption"]
 
 
+class NewsVideoPlayer(BaseModel):
+    provider: Literal["youtube", "twitch"]
+    media_id: str
+    player_url: str
+    external_url: str
+
+
 class NewsBlock(BaseModel):
     type: NewsBlockType
     runs: list[NewsTextRun] = Field(default_factory=list)
@@ -34,6 +41,7 @@ class NewsBlock(BaseModel):
     start: int = 1
     url: str | None = None
     alt: str = ""
+    player: NewsVideoPlayer | None = None
 
 
 # Response for `GET /api/v1/news/{id}`

--- a/app/services/news.py
+++ b/app/services/news.py
@@ -1,6 +1,5 @@
 import asyncio
 import http
-import re
 from datetime import datetime
 
 import dateutil.parser
@@ -9,39 +8,12 @@ from bs4 import BeautifulSoup, Tag
 from app import constants, schemas
 from app.core.connections import get_http_client
 from app.exceptions import ScrapingError
-from app.services.news_content import legacy_article_content, parse_article_blocks
+from app.services.news_content import parse_article_blocks, project_legacy_fields
 from app.utils import fix_datetime_tz
 
 # VLR returns 30 news cards per page. When fetching "all" pages we request them in
 # batches of this size and stop as soon as a page yields no cards.
 NEWS_PAGE_BATCH_SIZE = 5
-
-
-def _collapse_link_quote_padding(text: str) -> str:
-    result = []
-    last_end = 0
-    for match in re.finditer(r"\s+({{link_\d+}})\s+", text):
-        prev_char = text[match.start() - 1] if match.start() > 0 else ""
-        next_char = text[match.end()] if match.end() < len(text) else ""
-        is_quoted_link = (prev_char == next_char == '"') or (prev_char == "“" and next_char == "”")
-        if not is_quoted_link:
-            continue
-
-        result.append(text[last_end : match.start()])
-        result.append(match.group(1))
-        last_end = match.end()
-
-    if not result:
-        return text
-
-    result.append(text[last_end:])
-    return "".join(result)
-
-
-def normalize_article_text(text: str) -> str:
-    text = re.sub(r"\s+([.,;:!?])", r"\1", text)
-    text = re.sub(r"({{link_\d+}})\s+(['’]s)\b", r"\1\2", text)
-    return _collapse_link_quote_padding(text)
 
 
 def news_url(page: int) -> str:
@@ -168,10 +140,11 @@ def _parse_article_date(value: str) -> datetime | None:
 
 
 async def news_by_id(id: str) -> schemas.NewsArticle:
-    """
-    Function to fetch a news article by ID from VLR
-    :param id: The news article ID
-    :return: The parsed news article
+    """Fetch and parse a news article by ID from VLR.
+
+    :param id: The news article ID.
+    :return: The parsed article with ordered blocks and legacy projections.
+    :raises ScrapingError: If VLR returns a non-200 HTTP status.
     """
     async with get_http_client() as client:
         response = await client.get(constants.NEWS_URL_WITH_ID.format(id))
@@ -184,13 +157,10 @@ async def news_by_id(id: str) -> schemas.NewsArticle:
     article_container = soup.find("div", class_="wf-card mod-article")
 
     title = ""
-    content = ""
-    links = []
-    images = []
-    videos = []
     author = ""
     date = None
-    blocks = []
+    title_elem = None
+    meta_div = None
 
     if article_container:
         # Title
@@ -205,23 +175,15 @@ async def news_by_id(id: str) -> schemas.NewsArticle:
             if (date_elem := meta_div.find(class_="js-date-toggle")) and date_elem.get("title"):
                 date = _parse_article_date(str(date_elem["title"]))
 
-    if not title and (title_elem := soup.find("h1") or soup.find("title")):
-        title = title_elem.get_text().strip()
-
-    content_div = (
-        (article_container.find("div", class_="article-body") if article_container else None)
-        or soup.find("div", class_="article-body")
-        or soup.find("div", class_="content")
-        or soup.find("article")
-        or soup.find("main")
-    )
-    if content_div:
-        blocks = parse_article_blocks(content_div)
-        content, links, images, videos = legacy_article_content(blocks)
-        content = normalize_article_text(content)
+    if not title:
+        title_elem = soup.find("h1") or soup.find("title")
+        if title_elem:
+            title = title_elem.get_text().strip()
 
     # Parse metadata - try different selectors
-    if meta_div := soup.find("div", class_="article-meta") or soup.find("div", class_="meta"):
+    if not (author and date) and (
+        meta_div := soup.find("div", class_="article-meta") or soup.find("div", class_="meta")
+    ):
         if not author:
             if author_elem := meta_div.find("span", class_="author"):
                 author = author_elem.get_text().strip().replace("by ", "").replace("By ", "")
@@ -236,14 +198,35 @@ async def news_by_id(id: str) -> schemas.NewsArticle:
             if date_elem:
                 date = _parse_article_date(date_elem.get_text().strip())
 
+    body_div = (
+        (article_container.find("div", class_="article-body") if article_container else None)
+        or soup.find("div", class_="article-body")
+        or soup.find("div", class_="content")
+    )
+    fallback_container = soup.find("article") or soup.find("main")
+    content_div = body_div or fallback_container
+
+    if not body_div and fallback_container:
+        if title_elem and any(p is fallback_container for p in title_elem.parents):
+            header = title_elem.find_parent("header")
+            if header and any(p is fallback_container for p in header.parents):
+                header.extract()
+            else:
+                title_elem.extract()
+        if meta_div and any(p is fallback_container for p in meta_div.parents):
+            meta_div.extract()
+
+    blocks = parse_article_blocks(content_div) if content_div else []
+    legacy = project_legacy_fields(blocks)
+
     return schemas.NewsArticle(
         id=id,
         title=title,
-        content=content.strip(),
+        content=legacy.content,
         blocks=blocks,
-        links=links,
-        images=images,
-        videos=videos,
+        links=legacy.links,
+        images=legacy.images,
+        videos=legacy.videos,
         date=date,
         author=author,
     )

--- a/app/services/news.py
+++ b/app/services/news.py
@@ -1,17 +1,16 @@
 import asyncio
 import http
 import re
+from datetime import datetime
 
 import dateutil.parser
 from bs4 import BeautifulSoup, Tag
-from bs4.element import NavigableString
-from app.exceptions import ScrapingError
 
-from app import schemas
-import app.constants as constants
+from app import constants, schemas
 from app.core.connections import get_http_client
-from app.utils import expand_url, fix_datetime_tz, get_image_url
-
+from app.exceptions import ScrapingError
+from app.services.news_content import legacy_article_content, parse_article_blocks
+from app.utils import fix_datetime_tz
 
 # VLR returns 30 news cards per page. When fetching "all" pages we request them in
 # batches of this size and stop as soon as a page yields no cards.
@@ -40,44 +39,9 @@ def _collapse_link_quote_padding(text: str) -> str:
 
 
 def normalize_article_text(text: str) -> str:
-    text = re.sub(r'\s+([.,;:!?])', r'\1', text)
+    text = re.sub(r"\s+([.,;:!?])", r"\1", text)
     text = re.sub(r"({{link_\d+}})\s+(['’]s)\b", r"\1\2", text)
     return _collapse_link_quote_padding(text)
-
-
-def extract_text_and_links(element: Tag, counter: int) -> tuple[str, list[dict[str, str]], int]:
-    """
-    Recursively extracts text and links from a BeautifulSoup element.
-
-    :param element: The BeautifulSoup Tag to process
-    :param counter: Current counter for link placeholders
-    :return: Tuple of (processed_text, links_list, updated_counter)
-    """
-    text_parts = []
-    local_links = []
-    for child in element.children:
-        if isinstance(child, NavigableString):
-            t = " ".join(child.strip().split())
-            if t:
-                text_parts.append(t)
-        elif isinstance(child, Tag):
-            if child.name == "a":
-                link_text = " ".join(child.get_text().strip().split())
-                href = child.get("href")
-                if link_text and href:
-                    text_parts.append(f"{{{{link_{counter}}}}}")  # Double braces for literal
-                    local_links.append({"text": link_text, "url": expand_url(str(href))})
-                    counter += 1
-            elif child.name in ["span", "strong", "em", "b", "i", "br"]:  # Inline tags
-                sub_text, sub_links, counter = extract_text_and_links(child, counter)
-                text_parts.append(sub_text)
-                local_links.extend(sub_links)
-            else:
-                # For other tags, get text
-                t = " ".join(child.get_text().strip().split())
-                if t:
-                    text_parts.append(t)
-    return normalize_article_text(" ".join(text_parts)), local_links, counter
 
 
 def news_url(page: int) -> str:
@@ -196,6 +160,13 @@ def parse_news(data: Tag) -> schemas.NewsItem:
     )
 
 
+def _parse_article_date(value: str) -> datetime | None:
+    try:
+        return fix_datetime_tz(dateutil.parser.parse(value, ignoretz=True))
+    except ValueError, OverflowError:
+        return None
+
+
 async def news_by_id(id: str) -> schemas.NewsArticle:
     """
     Function to fetch a news article by ID from VLR
@@ -219,98 +190,35 @@ async def news_by_id(id: str) -> schemas.NewsArticle:
     videos = []
     author = ""
     date = None
-    counter = 0
+    blocks = []
 
     if article_container:
         # Title
         if title_elem := article_container.find("h1", class_="wf-title mod-article-title"):
             title = title_elem.get_text().strip()
 
-        # Content
-        content_div = (
-            soup.find("div", class_="content")
-            or soup.find("div", class_="article-body")
-            or soup.find("article")
-            or soup.find("main")
-        )
-        if content_div:
-            # Remove hover cards to avoid duplicate links
-            for hover in content_div.find_all("span", class_="wf-hover-card"):
-                hover.decompose()
-            for element in content_div.find_all(["p", "h2", "h3", "ul", "ol"]):
-                if element.name in ["p", "h2", "h3"]:
-                    text, new_links, counter = extract_text_and_links(element, counter)
-                    content += text + "\n\n"
-                    links.extend(new_links)
-                elif element.name == "ul":
-                    for li in element.find_all("li"):
-                        text, new_links, counter = extract_text_and_links(li, counter)
-                        if text.strip():
-                            content += f"- {text}\n"
-                            links.extend(new_links)
-                    content += "\n"
-                elif element.name == "ol":
-                    for i, li in enumerate(element.find_all("li")):
-                        text, new_links, counter = extract_text_and_links(li, counter)
-                        if text.strip():
-                            content += f"{i + 1}. {text}\n"
-                            links.extend(new_links)
-                    content += "\n"
-            # Check for standalone images/videos
-            for img in content_div.find_all("img"):
-                if src := img.get("src"):
-                    src_str = str(src)
-                    content += "{{image_{}}}\n\n".format(len(images))
-                    images.append(get_image_url(src_str))
-            for vid in content_div.find_all(["iframe", "video"]):
-                if src := vid.get("src"):
-                    src_str = str(src)
-                    content += "{{video_{}}}\n\n".format(len(videos))
-                    videos.append(get_image_url(src_str))
-
         # Metadata
         if meta_div := article_container.find("div", class_="article-meta"):
             if author_elem := meta_div.find("a", class_="article-meta-author"):
                 author = author_elem.get_text().strip()
 
-            if date_elem := meta_div.find("span", class_="js-date-toggle"):
-                if date_elem.get("title"):
-                    try:
-                        date = fix_datetime_tz(dateutil.parser.parse(str(date_elem["title"]), ignoretz=True))
-                    except Exception:
-                        pass
+            if (date_elem := meta_div.find(class_="js-date-toggle")) and date_elem.get("title"):
+                date = _parse_article_date(str(date_elem["title"]))
 
-    # Fallback for title
-    if not title:
-        if title_tag := soup.find("title"):
-            title = title_tag.get_text().strip()
-    else:
-        # Fallback: try to find title and content anywhere
-        if title_elem := soup.find("h1") or soup.find("title"):
-            title = title_elem.get_text().strip()
+    if not title and (title_elem := soup.find("h1") or soup.find("title")):
+        title = title_elem.get_text().strip()
 
-        # Look for main content
-        content_div = soup.find("div", class_="content") or soup.find("article") or soup.find("main")
-        if content_div:
-            for element in content_div.find_all(["p", "h2", "h3", "ul", "ol"]):
-                if element.name in ["p", "h2", "h3"]:
-                    text, new_links, counter = extract_text_and_links(element, counter)
-                    content += text + "\n\n"
-                    links.extend(new_links)
-                elif element.name == "ul":
-                    for li in element.find_all("li"):
-                        text, new_links, counter = extract_text_and_links(li, counter)
-                        if text.strip():
-                            content += f"- {text}\n"
-                            links.extend(new_links)
-                    content += "\n"
-                elif element.name == "ol":
-                    for i, li in enumerate(element.find_all("li")):
-                        text, new_links, counter = extract_text_and_links(li, counter)
-                        if text.strip():
-                            content += f"{i + 1}. {text}\n"
-                            links.extend(new_links)
-                    content += "\n"
+    content_div = (
+        (article_container.find("div", class_="article-body") if article_container else None)
+        or soup.find("div", class_="article-body")
+        or soup.find("div", class_="content")
+        or soup.find("article")
+        or soup.find("main")
+    )
+    if content_div:
+        blocks = parse_article_blocks(content_div)
+        content, links, images, videos = legacy_article_content(blocks)
+        content = normalize_article_text(content)
 
     # Parse metadata - try different selectors
     if meta_div := soup.find("div", class_="article-meta") or soup.find("div", class_="meta"):
@@ -326,21 +234,13 @@ async def news_by_id(id: str) -> schemas.NewsArticle:
         if not date:
             date_elem = meta_div.find("span", class_="date") or meta_div.find("time")
             if date_elem:
-                try:
-                    date = fix_datetime_tz(dateutil.parser.parse(str(date_elem.get_text().strip()), ignoretz=True))
-                except Exception:
-                    pass
-
-    # If still no title, try page title
-    if not title:
-        title_tag = soup.find("title")
-        if title_tag:
-            title = title_tag.get_text().strip()
+                date = _parse_article_date(date_elem.get_text().strip())
 
     return schemas.NewsArticle(
         id=id,
         title=title,
         content=content.strip(),
+        blocks=blocks,
         links=links,
         images=images,
         videos=videos,

--- a/app/services/news_content.py
+++ b/app/services/news_content.py
@@ -1,21 +1,36 @@
 """Convert an article body to ordered content without flattening its structure."""
 
+import itertools
 import re
-from urllib.parse import urljoin
+from collections.abc import Iterator
+from typing import NamedTuple
 
 from bs4 import Comment, NavigableString, Tag
 
-from app.constants import PREFIX
 from app.schemas.news import NewsBlock, NewsBlockType, NewsTextRun
 from app.services.news_video import news_video_player
+from app.utils import resolve_http_url
 
 _SKIP_TAGS = {"script", "style", "noscript", "template"}
 _CONTAINERS = {"div", "section", "article", "main", "figure", "header", "footer"}
 _HEADINGS = {f"h{level}" for level in range(1, 7)}
+_NESTED_BLOCKS: dict[str, NewsBlockType] = {
+    "blockquote": "blockquote",
+    "ul": "list",
+    "ol": "list",
+    "li": "list_item",
+}
+_CLOSING_QUOTE = re.compile(r' *(["”])')
+_POSSESSIVE_SPACE = re.compile(r" +(?=['’]s\b)")
 
 
-def _url(value: object) -> str | None:
-    return urljoin(PREFIX + "/", str(value)) if value else None
+class LegacyArticleFields(NamedTuple):
+    """Placeholder-based article fields retained for backward compatibility."""
+
+    content: str
+    links: list[dict[str, str]]
+    images: list[str]
+    videos: list[str]
 
 
 def _clean_runs(runs: list[NewsTextRun]) -> list[NewsTextRun]:
@@ -43,10 +58,18 @@ def _clean_runs(runs: list[NewsTextRun]) -> list[NewsTextRun]:
 
 
 def _normalize_run_spacing(runs: list[NewsTextRun]) -> list[NewsTextRun]:
+    """Normalize inline spacing without rescanning prefixes for each link.
+
+    :param runs: Cleaned runs from one article block.
+    :return: Runs with normalized spacing and retained link/style metadata.
+    """
+    if not runs:
+        return runs
     text = "".join(run.text for run in runs)
     remove: set[int] = set()
     for match in re.finditer(r" +(?=[.,;:!?])", text):
         remove.update(range(match.start(), match.end()))
+    opening_quotes = {match.end(): match for match in re.finditer(r'(["“]) *', text)}
 
     offset = 0
     index = 0
@@ -63,13 +86,16 @@ def _normalize_run_spacing(runs: list[NewsTextRun]) -> list[NewsTextRun]:
         linked_text = text[start:offset]
         core_start = start + len(linked_text) - len(linked_text.lstrip(" "))
         core_end = offset - len(linked_text) + len(linked_text.rstrip(" "))
-        opening = re.search(r'(["“]) *$', text[:core_start])
-        closing = re.match(r' *(["”])', text[core_end:])
+        opening = opening_quotes.get(core_start)
+        closing = _CLOSING_QUOTE.match(text, core_end)
         if opening and closing and (opening[1], closing[1]) in {('"', '"'), ("“", "”")}:
             remove.update(range(opening.start() + 1, core_start))
-            remove.update(range(core_end, core_end + closing.end() - 1))
-        if possessive := re.match(r" +(?=['’]s\b)", text[core_end:]):
-            remove.update(range(core_end, core_end + possessive.end()))
+            remove.update(range(core_end, closing.end() - 1))
+        if possessive := _POSSESSIVE_SPACE.match(text, core_end):
+            remove.update(range(core_end, possessive.end()))
+
+    if not remove:
+        return runs
 
     offset = 0
     result = []
@@ -81,121 +107,133 @@ def _normalize_run_spacing(runs: list[NewsTextRun]) -> list[NewsTextRun]:
     return result
 
 
-def parse_article_blocks(body: Tag) -> list[NewsBlock]:
-    """Walk each DOM node once, retaining inline styles and block boundaries."""
+def parse_article_blocks(
+    body: Tag,
+    kind: NewsBlockType = "paragraph",
+    level: int | None = None,
+    bold: bool = False,
+    italic: bool = False,
+    url: str | None = None,
+) -> list[NewsBlock]:
+    """Parse supported article tags into ordered content blocks.
 
-    def flow(
-        parent: Tag,
-        kind: NewsBlockType = "paragraph",
-        level: int | None = None,
-        bold: bool = False,
-        italic: bool = False,
-        url: str | None = None,
-    ) -> list[NewsBlock]:
-        blocks: list[NewsBlock] = []
-        pending: list[NewsTextRun] = []
+    Media blocks keep their source in ``url`` and any wrapping anchor in the
+    distinct ``link_url`` field. Optional arguments carry parsing state through
+    recursive calls.
 
-        def flush() -> None:
-            nonlocal pending
-            runs = _clean_runs(pending)
-            pending = []
-            if runs:
-                # VLR writes photo captions as italic text after an image in a paragraph.
-                is_caption = (
-                    parent.name == "p"
-                    and blocks
-                    and blocks[-1].type == "image"
-                    and all(run.italic for run in runs if run.text.strip())
-                )
-                blocks.append(NewsBlock(type="caption" if is_caption else kind, runs=runs, level=level))
-
-        def visit(node: object, bold: bool, italic: bool, url: str | None) -> None:
-            if isinstance(node, Comment):
-                return
-            if isinstance(node, NavigableString):
-                pending.append(NewsTextRun(text=re.sub(r"\s+", " ", str(node)), url=url, bold=bold, italic=italic))
-                return
-            if not isinstance(node, Tag):
-                return
-            if node.name in _SKIP_TAGS or "wf-hover-card" in (node.get("class") or []):
-                return
-            bold = bold or node.name in {"b", "strong"}
-            italic = italic or node.name in {"i", "em"}
-            if node.name == "br":
-                pending.append(NewsTextRun(text="\n", url=url, bold=bold, italic=italic))
-                return
-            if node.name in {"img", "iframe", "video"}:
-                source = node.get("src")
-                if not source and node.name == "video":
-                    source_tag = node.find("source", src=True)
-                    source = source_tag.get("src") if source_tag else None
-                if source:
-                    flush()
-                    blocks.append(
-                        NewsBlock(
-                            type="image" if node.name == "img" else "video",
-                            url=_url(source),
-                            player=news_video_player(_url(source) or "") if node.name != "img" else None,
-                            alt=str(node.get("alt", "")) if node.name == "img" else "",
-                        )
-                    )
-                return
-            if node.name in {"blockquote", "ul", "ol", "li"}:
-                flush()
-                children = flow(node, bold=bold, italic=italic, url=url)
-                if children:
-                    node_kind: NewsBlockType = (
-                        "list" if node.name in {"ul", "ol"} else "list_item" if node.name == "li" else "blockquote"
-                    )
-                    try:
-                        start = int(str(node.get("start", "1")))
-                    except ValueError:
-                        start = 1
-                    blocks.append(NewsBlock(type=node_kind, children=children, ordered=node.name == "ol", start=start))
-                return
-            if node.name in _CONTAINERS or node.name in _HEADINGS or node.name in {"p", "figcaption"}:
-                flush()
-                node_kind = (
-                    "heading" if node.name in _HEADINGS else "caption" if node.name == "figcaption" else "paragraph"
-                )
-                node_level = int(node.name[1]) if node.name in _HEADINGS else None
-                blocks.extend(flow(node, node_kind, node_level, bold, italic, url))
-                return
-            if node.name == "a":
-                url = _url(node.get("href")) or url
-            for child in node.children:
-                visit(child, bold, italic, url)
-
-        for child in parent.children:
-            visit(child, bold, italic, url)
-        flush()
-        return blocks
-
-    return flow(body)
+    :param body: Container whose children are read in document order.
+    :param kind: Block type for text directly inside this container.
+    :param level: Heading level for text blocks, if applicable.
+    :param bold: Inherited bold formatting.
+    :param italic: Inherited italic formatting.
+    :param url: Inherited anchor destination.
+    :return: Blocks assembled from text groups and nested content.
+    """
+    blocks: list[NewsBlock] = []
+    items = (item for child in body.children for item in _read_node(child, bold, italic, url))
+    grouped_items = itertools.groupby(items, key=lambda item: isinstance(item, NewsTextRun))
+    for is_text, group in grouped_items:
+        if not is_text:
+            blocks.extend(item for item in group if isinstance(item, NewsBlock))
+            continue
+        runs = _clean_runs([item for item in group if isinstance(item, NewsTextRun)])
+        if runs:
+            # VLR writes media captions as italic text immediately after the media.
+            is_caption = (
+                blocks and blocks[-1].type in {"image", "video"} and all(run.italic for run in runs if run.text.strip())
+            )
+            blocks.append(NewsBlock(type="caption" if is_caption else kind, runs=runs, level=level))
+    return blocks
 
 
-def legacy_article_content(blocks: list[NewsBlock]) -> tuple[str, list[dict[str, str]], list[str], list[str]]:
-    """Project the ordered blocks onto the original placeholder-based fields."""
+def _read_node(node: object, bold: bool, italic: bool, url: str | None) -> Iterator[NewsTextRun | NewsBlock | None]:
+    """Read a node as text segments, completed blocks, or block boundaries.
+
+    :param node: The BeautifulSoup node to read.
+    :param bold: Inherited bold formatting.
+    :param italic: Inherited italic formatting.
+    :param url: Inherited anchor destination, distinct from a media source.
+    :yield: Text runs, blocks, or ``None`` to separate text around an empty block.
+    """
+    if isinstance(node, Comment):
+        return
+    if isinstance(node, NavigableString):
+        yield NewsTextRun(text=re.sub(r"\s+", " ", str(node)), url=url, bold=bold, italic=italic)
+        return
+    if not isinstance(node, Tag):
+        return
+    if node.name in _SKIP_TAGS or "wf-hover-card" in (node.get("class") or []):
+        return
+    bold = bold or node.name in {"b", "strong"}
+    italic = italic or node.name in {"i", "em"}
+    if node.name == "br":
+        yield NewsTextRun(text="\n", url=url, bold=bold, italic=italic)
+        return
+    if node.name in {"img", "iframe", "video"}:
+        source = node.get("src")
+        if not source and node.name == "video":
+            source_tag = node.find("source", src=True)
+            source = source_tag.get("src") if source_tag else None
+        if media_url := resolve_http_url(source):
+            yield NewsBlock(
+                type="image" if node.name == "img" else "video",
+                url=media_url,
+                link_url=url,
+                player=news_video_player(media_url) if node.name != "img" else None,
+                alt=str(node.get("alt", "")) if node.name == "img" else "",
+            )
+        return
+    if node.name in _NESTED_BLOCKS:
+        yield None
+        if children := parse_article_blocks(node, bold=bold, italic=italic, url=url):
+            try:
+                start = int(str(node.get("start", "1")))
+            except ValueError:
+                start = 1
+            yield NewsBlock(type=_NESTED_BLOCKS[node.name], children=children, ordered=node.name == "ol", start=start)
+        return
+    if node.name in _CONTAINERS or node.name in _HEADINGS or node.name in {"p", "figcaption"}:
+        yield None
+        kind: NewsBlockType = (
+            "heading" if node.name in _HEADINGS else "caption" if node.name == "figcaption" else "paragraph"
+        )
+        level = int(node.name[1]) if node.name in _HEADINGS else None
+        yield from parse_article_blocks(node, kind, level, bold, italic, url)
+        return
+    if node.name == "a":
+        url = resolve_http_url(node.get("href"))
+    for child in node.children:
+        yield from _read_node(child, bold, italic, url)
+
+
+def project_legacy_fields(blocks: list[NewsBlock]) -> LegacyArticleFields:
+    """Project ordered blocks onto the original placeholder-based fields.
+
+    Linked text becomes ``{{link_N}}`` and media becomes ``{image_N}`` or
+    ``{video_N}``, with corresponding values stored in separate lists.
+
+    :param blocks: Ordered article blocks to flatten into legacy fields.
+    :return: Legacy content, links, images, and videos with matching indexes.
+    """
     links: list[dict[str, str]] = []
     images: list[str] = []
     videos: list[str] = []
 
     def inline(runs: list[NewsTextRun]) -> str:
+        """Render text runs and collect linked text in the captured links list.
+
+        :param runs: Inline text runs to render.
+        :return: Text containing ``{{link_N}}`` placeholders for linked runs.
+        """
         parts: list[str] = []
-        index = 0
-        while index < len(runs):
-            run = runs[index]
-            text = run.text
-            index += 1
-            if run.url:
-                while index < len(runs) and runs[index].url == run.url:
-                    text += runs[index].text
-                    index += 1
+        for url, group in itertools.groupby(runs, key=lambda run: run.url):
+            text = "".join(run.text for run in group)
+            if url:
                 leading = text[: len(text) - len(text.lstrip())]
                 trailing = text[len(text.rstrip()) :]
                 if text.strip():
                     parts.append(f"{leading}{{{{link_{len(links)}}}}}{trailing}")
-                    links.append({"text": text.strip(), "url": run.url})
+                    links.append({"text": text.strip(), "url": url})
                 else:
                     parts.append(text)
             else:
@@ -224,4 +262,9 @@ def legacy_article_content(blocks: list[NewsBlock]) -> tuple[str, list[dict[str,
         parts.extend(render(child) for child in block.children)
         return "\n\n".join(part for part in parts if part)
 
-    return "\n\n".join(render(block) for block in blocks).strip(), links, images, videos
+    return LegacyArticleFields(
+        content="\n\n".join(render(block) for block in blocks).strip(),
+        links=links,
+        images=images,
+        videos=videos,
+    )

--- a/app/services/news_content.py
+++ b/app/services/news_content.py
@@ -1,0 +1,225 @@
+"""Convert an article body to ordered content without flattening its structure."""
+
+import re
+from urllib.parse import urljoin
+
+from bs4 import Comment, NavigableString, Tag
+
+from app.constants import PREFIX
+from app.schemas.news import NewsBlock, NewsBlockType, NewsTextRun
+
+_SKIP_TAGS = {"script", "style", "noscript", "template"}
+_CONTAINERS = {"div", "section", "article", "main", "figure", "header", "footer"}
+_HEADINGS = {f"h{level}" for level in range(1, 7)}
+
+
+def _url(value: object) -> str | None:
+    return urljoin(PREFIX + "/", str(value)) if value else None
+
+
+def _clean_runs(runs: list[NewsTextRun]) -> list[NewsTextRun]:
+    cleaned: list[NewsTextRun] = []
+    for run in runs:
+        text = run.text
+        if not cleaned:
+            text = text.lstrip(" \n")
+        elif cleaned[-1].text.endswith((" ", "\n")):
+            text = text.lstrip(" ")
+        if text.startswith("\n") and cleaned:
+            cleaned[-1].text = cleaned[-1].text.rstrip(" ")
+        if not text:
+            continue
+        if cleaned and (cleaned[-1].url, cleaned[-1].bold, cleaned[-1].italic) == (run.url, run.bold, run.italic):
+            cleaned[-1].text += text
+        else:
+            cleaned.append(run.model_copy(update={"text": text}))
+    while cleaned:
+        cleaned[-1].text = cleaned[-1].text.rstrip(" \n")
+        if cleaned[-1].text:
+            break
+        cleaned.pop()
+    return _normalize_run_spacing(cleaned)
+
+
+def _normalize_run_spacing(runs: list[NewsTextRun]) -> list[NewsTextRun]:
+    text = "".join(run.text for run in runs)
+    remove: set[int] = set()
+    for match in re.finditer(r" +(?=[.,;:!?])", text):
+        remove.update(range(match.start(), match.end()))
+
+    offset = 0
+    index = 0
+    while index < len(runs):
+        run = runs[index]
+        start = offset
+        offset += len(run.text)
+        index += 1
+        if not run.url:
+            continue
+        while index < len(runs) and runs[index].url == run.url:
+            offset += len(runs[index].text)
+            index += 1
+        linked_text = text[start:offset]
+        core_start = start + len(linked_text) - len(linked_text.lstrip(" "))
+        core_end = offset - len(linked_text) + len(linked_text.rstrip(" "))
+        opening = re.search(r'(["“]) *$', text[:core_start])
+        closing = re.match(r' *(["”])', text[core_end:])
+        if opening and closing and (opening[1], closing[1]) in {('"', '"'), ("“", "”")}:
+            remove.update(range(opening.start() + 1, core_start))
+            remove.update(range(core_end, core_end + closing.end() - 1))
+        if possessive := re.match(r" +(?=['’]s\b)", text[core_end:]):
+            remove.update(range(core_end, core_end + possessive.end()))
+
+    offset = 0
+    result = []
+    for run in runs:
+        normalized = "".join(char for index, char in enumerate(run.text, offset) if index not in remove)
+        offset += len(run.text)
+        if normalized:
+            result.append(run.model_copy(update={"text": normalized}))
+    return result
+
+
+def parse_article_blocks(body: Tag) -> list[NewsBlock]:
+    """Walk each DOM node once, retaining inline styles and block boundaries."""
+
+    def flow(
+        parent: Tag,
+        kind: NewsBlockType = "paragraph",
+        level: int | None = None,
+        bold: bool = False,
+        italic: bool = False,
+        url: str | None = None,
+    ) -> list[NewsBlock]:
+        blocks: list[NewsBlock] = []
+        pending: list[NewsTextRun] = []
+
+        def flush() -> None:
+            nonlocal pending
+            runs = _clean_runs(pending)
+            pending = []
+            if runs:
+                # VLR writes photo captions as italic text after an image in a paragraph.
+                is_caption = (
+                    parent.name == "p"
+                    and blocks
+                    and blocks[-1].type == "image"
+                    and all(run.italic for run in runs if run.text.strip())
+                )
+                blocks.append(NewsBlock(type="caption" if is_caption else kind, runs=runs, level=level))
+
+        def visit(node: object, bold: bool, italic: bool, url: str | None) -> None:
+            if isinstance(node, Comment):
+                return
+            if isinstance(node, NavigableString):
+                pending.append(NewsTextRun(text=re.sub(r"\s+", " ", str(node)), url=url, bold=bold, italic=italic))
+                return
+            if not isinstance(node, Tag):
+                return
+            if node.name in _SKIP_TAGS or "wf-hover-card" in (node.get("class") or []):
+                return
+            bold = bold or node.name in {"b", "strong"}
+            italic = italic or node.name in {"i", "em"}
+            if node.name == "br":
+                pending.append(NewsTextRun(text="\n", url=url, bold=bold, italic=italic))
+                return
+            if node.name in {"img", "iframe", "video"}:
+                source = node.get("src")
+                if not source and node.name == "video":
+                    source_tag = node.find("source", src=True)
+                    source = source_tag.get("src") if source_tag else None
+                if source:
+                    flush()
+                    blocks.append(
+                        NewsBlock(
+                            type="image" if node.name == "img" else "video",
+                            url=_url(source),
+                            alt=str(node.get("alt", "")) if node.name == "img" else "",
+                        )
+                    )
+                return
+            if node.name in {"blockquote", "ul", "ol", "li"}:
+                flush()
+                children = flow(node, bold=bold, italic=italic, url=url)
+                if children:
+                    node_kind: NewsBlockType = (
+                        "list" if node.name in {"ul", "ol"} else "list_item" if node.name == "li" else "blockquote"
+                    )
+                    try:
+                        start = int(str(node.get("start", "1")))
+                    except ValueError:
+                        start = 1
+                    blocks.append(NewsBlock(type=node_kind, children=children, ordered=node.name == "ol", start=start))
+                return
+            if node.name in _CONTAINERS or node.name in _HEADINGS or node.name in {"p", "figcaption"}:
+                flush()
+                node_kind = (
+                    "heading" if node.name in _HEADINGS else "caption" if node.name == "figcaption" else "paragraph"
+                )
+                node_level = int(node.name[1]) if node.name in _HEADINGS else None
+                blocks.extend(flow(node, node_kind, node_level, bold, italic, url))
+                return
+            if node.name == "a":
+                url = _url(node.get("href")) or url
+            for child in node.children:
+                visit(child, bold, italic, url)
+
+        for child in parent.children:
+            visit(child, bold, italic, url)
+        flush()
+        return blocks
+
+    return flow(body)
+
+
+def legacy_article_content(blocks: list[NewsBlock]) -> tuple[str, list[dict[str, str]], list[str], list[str]]:
+    """Project the ordered blocks onto the original placeholder-based fields."""
+    links: list[dict[str, str]] = []
+    images: list[str] = []
+    videos: list[str] = []
+
+    def inline(runs: list[NewsTextRun]) -> str:
+        parts: list[str] = []
+        index = 0
+        while index < len(runs):
+            run = runs[index]
+            text = run.text
+            index += 1
+            if run.url:
+                while index < len(runs) and runs[index].url == run.url:
+                    text += runs[index].text
+                    index += 1
+                leading = text[: len(text) - len(text.lstrip())]
+                trailing = text[len(text.rstrip()) :]
+                if text.strip():
+                    parts.append(f"{leading}{{{{link_{len(links)}}}}}{trailing}")
+                    links.append({"text": text.strip(), "url": run.url})
+                else:
+                    parts.append(text)
+            else:
+                parts.append(text)
+        return "".join(parts)
+
+    def render(block: NewsBlock) -> str:
+        if block.type in {"image", "video"} and block.url:
+            media = images if block.type == "image" else videos
+            placeholder = f"{{{block.type}_{len(media)}}}"
+            media.append(block.url)
+            return placeholder
+        if block.type == "list":
+            items = []
+            number = block.start
+            for child in block.children:
+                text = render(child)
+                if child.type == "list_item":
+                    prefix = f"{number}. " if block.ordered else "- "
+                    items.append(prefix + text.replace("\n", "\n  "))
+                    number += 1
+                else:
+                    items.append(text)
+            return "\n".join(items)
+        parts = [inline(block.runs)] if block.runs else []
+        parts.extend(render(child) for child in block.children)
+        return "\n\n".join(part for part in parts if part)
+
+    return "\n\n".join(render(block) for block in blocks).strip(), links, images, videos

--- a/app/services/news_content.py
+++ b/app/services/news_content.py
@@ -7,6 +7,7 @@ from bs4 import Comment, NavigableString, Tag
 
 from app.constants import PREFIX
 from app.schemas.news import NewsBlock, NewsBlockType, NewsTextRun
+from app.services.news_video import news_video_player
 
 _SKIP_TAGS = {"script", "style", "noscript", "template"}
 _CONTAINERS = {"div", "section", "article", "main", "figure", "header", "footer"}
@@ -134,6 +135,7 @@ def parse_article_blocks(body: Tag) -> list[NewsBlock]:
                         NewsBlock(
                             type="image" if node.name == "img" else "video",
                             url=_url(source),
+                            player=news_video_player(_url(source) or "") if node.name != "img" else None,
                             alt=str(node.get("alt", "")) if node.name == "img" else "",
                         )
                     )

--- a/app/services/news_video.py
+++ b/app/services/news_video.py
@@ -3,18 +3,32 @@
 import re
 from urllib.parse import parse_qs, urlsplit
 
+from app.constants import NewsVideoProvider
 from app.schemas.news import NewsVideoPlayer
 
-_YOUTUBE_ID = re.compile(r"[A-Za-z0-9_-]{11}")
-_TWITCH_ID = re.compile(r"[A-Za-z0-9_-]{1,200}")
+_MEDIA_ID_PATTERNS = {
+    NewsVideoProvider.YOUTUBE: re.compile(r"[A-Za-z0-9_-]{11}"),
+    NewsVideoProvider.TWITCH: re.compile(r"[A-Za-z0-9_-]{1,200}"),
+}
 
 
-def valid_media_id(provider: str, media_id: str) -> bool:
-    pattern = {"youtube": _YOUTUBE_ID, "twitch": _TWITCH_ID}.get(provider)
+def valid_media_id(provider: NewsVideoProvider, media_id: str) -> bool:
+    """Validate a provider's ID syntax without checking whether the media exists.
+
+    :param provider: The hosted video provider.
+    :param media_id: The provider-specific identifier to validate.
+    :return: Whether the ID matches the provider's supported syntax.
+    """
+    pattern = _MEDIA_ID_PATTERNS.get(provider)
     return pattern is not None and pattern.fullmatch(media_id) is not None
 
 
 def news_video_player(url: str) -> NewsVideoPlayer | None:
+    """Recognize a video URL and build metadata for its hosted player.
+
+    :param url: Candidate YouTube video or Twitch clip URL.
+    :return: Provider metadata, or ``None`` for unsupported or malformed URLs.
+    """
     try:
         parsed = urlsplit(url)
         if parsed.scheme not in {"http", "https"} or parsed.username or parsed.password or parsed.port:
@@ -27,28 +41,28 @@ def news_video_player(url: str) -> NewsVideoPlayer | None:
     provider = None
     media_id = ""
     if host in {"youtube.com", "www.youtube.com", "m.youtube.com", "youtube-nocookie.com", "www.youtube-nocookie.com"}:
-        provider = "youtube"
+        provider = NewsVideoProvider.YOUTUBE
         if len(path) == 2 and path[0] == "embed":
             media_id = path[1]
         elif path == ["watch"] and host not in {"youtube-nocookie.com", "www.youtube-nocookie.com"}:
             media_id = query.get("v", [""])[0]
     elif host == "youtu.be" and len(path) == 1:
-        provider, media_id = "youtube", path[0]
+        provider, media_id = NewsVideoProvider.YOUTUBE, path[0]
     elif host == "clips.twitch.tv" and len(path) == 1:
-        provider = "twitch"
+        provider = NewsVideoProvider.TWITCH
         media_id = query.get("clip", [""])[0] if path == ["embed"] else path[0]
     elif host in {"twitch.tv", "www.twitch.tv"} and len(path) == 3 and path[1] == "clip":
-        provider, media_id = "twitch", path[2]
+        provider, media_id = NewsVideoProvider.TWITCH, path[2]
     if provider is None or not valid_media_id(provider, media_id):
         return None
     external = (
         f"https://www.youtube.com/watch?v={media_id}"
-        if provider == "youtube"
+        if provider is NewsVideoProvider.YOUTUBE
         else f"https://clips.twitch.tv/{media_id}"
     )
     return NewsVideoPlayer(
         provider=provider,
         media_id=media_id,
-        player_url=f"/media/{provider}/{media_id}",
+        player_url=f"/media/{provider.value}/{media_id}",
         external_url=external,
     )

--- a/app/services/news_video.py
+++ b/app/services/news_video.py
@@ -1,0 +1,54 @@
+"""Recognize supported provider URLs without fetching arbitrary media."""
+
+import re
+from urllib.parse import parse_qs, urlsplit
+
+from app.schemas.news import NewsVideoPlayer
+
+_YOUTUBE_ID = re.compile(r"[A-Za-z0-9_-]{11}")
+_TWITCH_ID = re.compile(r"[A-Za-z0-9_-]{1,200}")
+
+
+def valid_media_id(provider: str, media_id: str) -> bool:
+    pattern = {"youtube": _YOUTUBE_ID, "twitch": _TWITCH_ID}.get(provider)
+    return pattern is not None and pattern.fullmatch(media_id) is not None
+
+
+def news_video_player(url: str) -> NewsVideoPlayer | None:
+    try:
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or parsed.username or parsed.password or parsed.port:
+            return None
+        host = parsed.hostname
+        path = parsed.path.strip("/").split("/")
+        query = parse_qs(parsed.query)
+    except ValueError:
+        return None
+    provider = None
+    media_id = ""
+    if host in {"youtube.com", "www.youtube.com", "m.youtube.com", "youtube-nocookie.com", "www.youtube-nocookie.com"}:
+        provider = "youtube"
+        if len(path) == 2 and path[0] == "embed":
+            media_id = path[1]
+        elif path == ["watch"] and host not in {"youtube-nocookie.com", "www.youtube-nocookie.com"}:
+            media_id = query.get("v", [""])[0]
+    elif host == "youtu.be" and len(path) == 1:
+        provider, media_id = "youtube", path[0]
+    elif host == "clips.twitch.tv" and len(path) == 1:
+        provider = "twitch"
+        media_id = query.get("clip", [""])[0] if path == ["embed"] else path[0]
+    elif host in {"twitch.tv", "www.twitch.tv"} and len(path) == 3 and path[1] == "clip":
+        provider, media_id = "twitch", path[2]
+    if provider is None or not valid_media_id(provider, media_id):
+        return None
+    external = (
+        f"https://www.youtube.com/watch?v={media_id}"
+        if provider == "youtube"
+        else f"https://clips.twitch.tv/{media_id}"
+    )
+    return NewsVideoPlayer(
+        provider=provider,
+        media_id=media_id,
+        player_url=f"/media/{provider}/{media_id}",
+        external_url=external,
+    )

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,32 +1,46 @@
 import re
 from datetime import datetime
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse, urlsplit
 from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException
 from sentry_sdk.types import Event, Hint
 
-from app.constants import PREFIX, VLR_IMAGE
+from app.constants import PREFIX
 from app.core.config import settings
 
 _TZ_LOCAL = ZoneInfo(settings.TIMEZONE)
 _TZ_UTC = ZoneInfo("UTC")
 
 
+def resolve_http_url(value: str | list[str] | None) -> str | None:
+    """Resolve an HTTP(S) URL relative to the VLR root.
+
+    :param value: A URL attribute value, or list from BeautifulSoup.
+    :return: The resolved URL, or ``None`` when empty, unsupported, or malformed.
+    """
+    if isinstance(value, list):
+        value = value[0] if value else None
+    if not value or not (value := value.strip()):
+        return None
+    try:
+        resolved = urljoin(PREFIX + "/", value)
+        parsed = urlsplit(resolved)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            return None
+        _ = parsed.port  # urllib validates the port when this property is read.
+        return resolved
+    except ValueError:
+        return None
+
+
 def get_image_url(img: str | list[str]) -> str:
+    """Resolve an image URL while preserving the legacy string return type.
+
+    :param img: The image source, or list from BeautifulSoup.
+    :return: The resolved HTTP(S) URL, or an empty string when invalid.
     """
-    Determine an image URL based on the string
-    :param img: The src string of the image (or list from BeautifulSoup)
-    :return: The full URL
-    """
-    if isinstance(img, list):
-        img = img[0]
-    if img.startswith("http"):
-        return img
-    elif img.startswith(VLR_IMAGE):
-        return f"{PREFIX}{img}"
-    else:
-        return f"https:{img}"
+    return resolve_http_url(img) or ""
 
 
 def clear_datetime_tz(source: datetime) -> datetime:

--- a/app/web/media.py
+++ b/app/web/media.py
@@ -3,20 +3,30 @@
 from html import escape
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
+from app.constants import NewsVideoProvider
+from app.exceptions import NotFoundError
 from app.services.news_video import valid_media_id
 
 router = APIRouter()
 
 
 @router.get("/media/{provider}/{media_id}", response_class=HTMLResponse)
-async def media_player(request: Request, provider: str, media_id: str) -> HTMLResponse:
+async def media_player(request: Request, provider: NewsVideoProvider, media_id: str) -> HTMLResponse:
+    """Serve a provider iframe page for a syntactically valid media ID.
+
+    :param request: The request used to derive Twitch's parent hostname.
+    :param provider: Supported provider name (``youtube`` or ``twitch``).
+    :param media_id: Provider-specific media identifier.
+    :return: A secured HTML response containing the official provider iframe.
+    :raises NotFoundError: For an invalid media ID.
+    """
     if not valid_media_id(provider, media_id):
-        raise HTTPException(status_code=404, detail="Unsupported video")
-    if provider == "youtube":
-        query = urlencode({"origin": str(request.base_url).rstrip("/"), "playsinline": "1", "autoplay": "0"})
+        raise NotFoundError("Unsupported video")
+    if provider is NewsVideoProvider.YOUTUBE:
+        query = urlencode({"playsinline": "1", "autoplay": "0"})
         source = f"https://www.youtube.com/embed/{media_id}?{query}"
         title = "YouTube video player"
         frame_origin = "https://www.youtube.com"

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,12 +19,59 @@ Most endpoints are public. Some internal endpoints may require `X-API-Key` heade
 | GET | `/matches` | List matches with filtering options |
 | GET | `/matches/{id}` | Get detailed match information |
 | GET | `/news` | Get latest news articles |
+| GET | `/news/{id}` | Get an article with ordered content blocks |
 | GET | `/player/{id}` | Get player statistics |
 | GET | `/rankings` | Get current team rankings |
 | GET | `/standings/{year}` | Get VCT standings for a year |
 | GET | `/team/{id}` | Get team information |
 | GET | `/search` | Search teams, players, and events |
 | GET | `/version` | Get API version info |
+
+## News article content
+
+`GET /news/{id}` returns `blocks` in article document order. Clients should render
+these blocks directly; no client-side HTML parsing is required. Text, links, media,
+and nested content remain in their original positions.
+
+| Block `type` | Content |
+| --- | --- |
+| `paragraph` | `runs` of text |
+| `heading` | `runs` and heading `level`, from 1 to 6 |
+| `blockquote` | Ordered `children` blocks |
+| `list` | `children` containing `list_item` blocks; `ordered` and `start` specify numbering |
+| `list_item` | Ordered `children`, including paragraphs and nested lists |
+| `image` | Absolute `url` and `alt` text |
+| `video` | Absolute `url`, including iframe embeds and native video sources |
+| `caption` | `runs` from a figure caption or italic photo caption |
+
+Each text run has `text`, an optional absolute link `url`, and `bold` and `italic`
+flags. Concatenate runs exactly, retaining their spaces and newlines. A line break
+is represented by `\n` within a run. Formatting and links can overlap.
+
+For example, an introduction followed by a video and an interview question has
+this block sequence. Unused fields are omitted here for readability; responses
+include their defaults.
+
+```json
+[
+  {"type": "paragraph", "runs": [{"text": "Interview introduction.", "italic": true}]},
+  {"type": "video", "url": "https://www.youtube.com/embed/example"},
+  {"type": "paragraph", "runs": [{"text": "How did the match feel?", "bold": true}]},
+  {"type": "blockquote", "children": [
+    {"type": "paragraph", "runs": [{"text": "We felt prepared."}]}
+  ]}
+]
+```
+
+The existing `content`, `links`, `images`, and `videos` fields are generated from
+the same blocks. `content` uses `{{link_N}}`, `{image_N}`, and `{video_N}` as
+zero-based references to the corresponding arrays. These references now occur
+at their document positions, and heading text is included. Use `blocks` to retain
+heading levels, emphasis, quotes, and list structure.
+
+Article detail responses are scraped on request, unlike the cached news list.
+Clients with locally cached article bodies should fetch an article again when
+its cached response has no blocks.
 
 ## Interactive Documentation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,13 +40,16 @@ and nested content remain in their original positions.
 | `blockquote` | Ordered `children` blocks |
 | `list` | `children` containing `list_item` blocks; `ordered` and `start` specify numbering |
 | `list_item` | Ordered `children`, including paragraphs and nested lists |
-| `image` | Absolute `url` and `alt` text |
-| `video` | Absolute `url`, including iframe embeds and native video sources |
-| `caption` | `runs` from a figure caption or italic photo caption |
+| `image` | Absolute `url` and `alt` text; optional `link_url` when wrapped in a link |
+| `video` | Absolute `url`, including iframe embeds and native video sources; optional `link_url` when wrapped in a link |
+| `caption` | `runs` from a figure caption or italic media caption |
 
 Each text run has `text`, an optional absolute link `url`, and `bold` and `italic`
 flags. Concatenate runs exactly, retaining their spaces and newlines. A line break
-is represented by `\n` within a run. Formatting and links can overlap.
+is represented by `\n` within a run. Formatting and links can overlap. Link and
+media URLs are resolved against VLR and emitted only when they use HTTP or HTTPS.
+When an image or video is wrapped in an anchor link, its destination is preserved in
+`link_url`.
 
 For example, an introduction followed by a video and an interview question has
 this block sequence. Unused fields are omitted here for readability; responses

--- a/docs/news-media.md
+++ b/docs/news-media.md
@@ -2,28 +2,19 @@
 
 Video blocks retain their original `url`. Recognized YouTube videos and Twitch
 clips also include `player` with `provider`, `media_id`, `external_url`, and a
-relative `player_url`, for example `/media/youtube/vbBd_Hu6o2M`. Resolve that path
-against the API response origin. Unrecognized media has `player: null`; clients
-can continue opening the original URL externally.
+root-relative `player_url`, for example `/media/youtube/vbBd_Hu6o2M`. Resolve the
+path against the API response origin. Unrecognized media has
+`player: null`; clients can continue opening the original URL externally.
 
 `GET /media/{provider}/{media_id}` serves a small HTML page containing the official
-provider iframe. It is public even when the JSON API requires an API key, so a
-mobile WebView never needs to send API credentials to play a video. The route
-validates provider and ID and does not fetch or proxy arbitrary URLs. There are
-no additional dependencies. Load it on demand in a system WebView and release
-the WebView when playback closes or the article leaves the screen.
+provider iframe. It is public even when the JSON API requires an API key, so
+clients do not send API credentials to play a video. The route validates the
+provider and media ID and does not fetch or proxy arbitrary URLs.
 
-Serve the page over HTTPS. YouTube receives the page's origin; Twitch receives
-its hostname as `parent`. If using a reverse proxy, configure the server's
-trusted forwarded headers so FastAPI sees the external HTTPS scheme. Preserve
-`Referrer-Policy: strict-origin-when-cross-origin` and permit provider iframes;
-missing referrer identification can prevent YouTube playback. No autoplay is
-requested. YouTube requires a viewport of at least 200 by 200 pixels; Twitch
-clips require at least 400 by 300 pixels. On narrow mobile layouts, expand Twitch
-playback to a fullscreen presentation and ask the user to rotate if the available
-width is still below 400 pixels. Do not scale or crop the player to evade those
-minimums. Retain an external-open action if provider playback is unavailable.
-
-The page route must be deployed alongside the JSON API before clients can use
-`player_url`. Local HTTP can inspect layout and metadata, but real provider
-playback must also be tested on an HTTPS origin with provider connectivity.
+Provider playback requires HTTPS. Twitch receives the request hostname as
+`parent`. The page and provider iframe use
+`Referrer-Policy: strict-origin-when-cross-origin` so the browser sends only the
+page origin in the `Referer` header on the cross-origin iframe request.
+Clients must provide a viewport of at least 200 by 200 pixels for YouTube and
+400 by 300 pixels for Twitch clips. No autoplay is requested; retain an
+external-open fallback when embedded playback is unavailable.

--- a/docs/news-media.md
+++ b/docs/news-media.md
@@ -1,0 +1,29 @@
+# News video players
+
+Video blocks retain their original `url`. Recognized YouTube videos and Twitch
+clips also include `player` with `provider`, `media_id`, `external_url`, and a
+relative `player_url`, for example `/media/youtube/vbBd_Hu6o2M`. Resolve that path
+against the API response origin. Unrecognized media has `player: null`; clients
+can continue opening the original URL externally.
+
+`GET /media/{provider}/{media_id}` serves a small HTML page containing the official
+provider iframe. It is public even when the JSON API requires an API key, so a
+mobile WebView never needs to send API credentials to play a video. The route
+validates provider and ID and does not fetch or proxy arbitrary URLs. There are
+no additional dependencies. Load it on demand in a system WebView and release
+the WebView when playback closes or the article leaves the screen.
+
+Serve the page over HTTPS. YouTube receives the page's origin; Twitch receives
+its hostname as `parent`. If using a reverse proxy, configure the server's
+trusted forwarded headers so FastAPI sees the external HTTPS scheme. Preserve
+`Referrer-Policy: strict-origin-when-cross-origin` and permit provider iframes;
+missing referrer identification can prevent YouTube playback. No autoplay is
+requested. YouTube requires a viewport of at least 200 by 200 pixels; Twitch
+clips require at least 400 by 300 pixels. On narrow mobile layouts, expand Twitch
+playback to a fullscreen presentation and ask the user to rotate if the available
+width is still below 400 pixels. Do not scale or crop the player to evade those
+minimums. Retain an external-open action if provider playback is unavailable.
+
+The page route must be deployed alongside the JSON API before clients can use
+`player_url`. Local HTTP can inspect layout and metadata, but real provider
+playback must also be tested on an HTTPS origin with provider connectivity.

--- a/tests/fixtures/news_748106.html
+++ b/tests/fixtures/news_748106.html
@@ -1,0 +1,69 @@
+<!doctype html><html><body><div class="wf-card mod-article">
+<div class="article-header">
+<a class="article-header-event" href="/event/2976/vct-2026-emea-stage-2">
+<img src="//owcdn.net/img/65ab59620a233.png"/>
+<div>VCT 2026: EMEA Stage 2</div>
+</a>
+<h1 class="wf-title mod-article-title">
+			N4RRATE: "After I got kicked, I didn't know if I wanted to keep competing [this] season."		</h1>
+<div class="article-meta">
+<img class="article-meta-avatar" src="//owcdn.net/img/623360b6b5374.png"/>
+<div>
+<a class="article-meta-author" href="/user/ChickenJoe" style="margin-top: 2px;">ChickenJoe</a>
+<div>
+<time class="js-date-toggle" datetime="2026-08-31T04:50:26+05:30" title="Aug 31, 2026 at 04:50 IST">
+						5 days ago					</time>
+</div>
+</div>
+</div>
+</div>
+<div class="article-body">
+<style scoped="" type="text/css">
+</style>
+<p><em>Note: This article is a text port of our live interview with N4RRATE. The video interview can be found <a href="https://youtu.be/vbBd_Hu6o2M" target="_blank">here</a>.</em></p>
+<p></p><div class="embed-spacing"></div><iframe allowfullscreen="allowfullscreen" class="yt-embed" frameborder="0" src="//www.youtube.com/embed/vbBd_Hu6o2M?showinfo=0&amp;origin=https://www.vlr.gg" type="text/html"></iframe>
+<p><strong>N4RRATE, it's been a year for you, but how are you feeling now? You've come a long way from [an] 0-5 group stage to now lifting the Stage 2 trophy. Can you tell me a little bit of the emotions, the journey that you've been through this entire year?</strong></p>
+<blockquote>
+<p>It's definitely been like a bit of a roller coaster for sure. Obviously starting off with Sentinels and then moving to KC, [a] different region mid-season and then going from 0-5 to winning a trophy is very unexpected, I would say. I mean, it's very hard to be able to match that level of inconsistency where you're so inconsistent that you're going 0-5 and [then] you're just winning. So it's just weird for me. But overall, I think that I'm definitely on a super upward trend with [Karmine Corp] because I was definitely not very happy on Sentinels and after we went 0-5, and I think a lot of that is due to us losing and kind of losing myself a bit.
+  But I think ZE1SH and our performance coach Youenn did a very good job of putting us on the right path and being able to use our negative motions not against each other and being able to build on top of each other and trying to be a real, real team. I think that helped me a lot. And I think it's part of the reason we have such great success today is that everyone is very happy to play now. Before, we probably weren't as happy to play, and now we're just giving it our all every single day.</p>
+</blockquote>
+<p><strong>I'm sure…We've seen before just from posts put out [on social media] that you have a lot of passion for the game, so I'm sure it can get frustrating when things aren't going your way. I do want to talk about the change and the adaptation you've gone through since coming from Sentinels, because you're actually a really interesting player; you didn't really start competing until around [2023] with MAD LIONS officially. And then you go from there to Karmine Corp and then to Sentinels and then back. So what's it like, moving between regions, between teams? I'm sure it can't be easy for you. But what's it been like competing across all these different teams over the years?</strong></p>
+<blockquote>
+<p>It's been a bit of a speed run, I would say. I started playing in, like, mid-2022, hit rank one very fast and then, like, instantly started competing with MAD LIONS within, like nine or eight months of me playing the game. So I think it's kind of just been really fast.
+  I instantly went from playing on MAD LIONS for, like, only two months because our season ended instantly because we lost every game. But I got a lot of trials because of it. Trialing with infinite teams, getting accepted, but then I got rejected, [a lot of] weird stuff happened. And then, I got my only real offer from KC because [of] ENGH; he was on TSM that season and I played against him. So he always wanted to trial me because he knew I had potential. From there, everything just went really fast. We practiced a lot, won Kickoff, and then dipped really hard after.
+  Joining Sentinels for me was kind of like, ‘All right, I'm on like the best team,' you know? And then we didn't really show such results as we expected, even though our results were very good. Our results were very good on Sentinels.
+  But for us, we kind of set way higher expectations, which is kind of why [I'd say] maybe we didn't achieve as much as we wanted to. And then coming back to KC was kind of like, ‘Oh, am I really doing this?' Because after Sentinels, after I got kicked, I didn't know if I wanted to keep competing [this] season.
+  So yeah, I didn't really know what to do, especially after. I wasn't surprised and I don't know if I would have continued competing if I didn't get kicked anyways; I might have just benched myself.
+  I spoke about this in my stream. I was planning on benching myself before we played LEV last game because I felt like I wasn't impactful for the team and I wanted the team to succeed. So I knew that was kind of the only way the team would play better.
+  And then just joining KC randomly just because I trust ZE1SH a lot. I felt like he would, you know, put me in good positions and make me happy at least playing the game. I think going 0-5 is obviously not happy, but after that I think it's been smooth sailing.</p>
+</blockquote>
+<p><strong>I want to compare your form now. You guys are in really nice form. You've played a bunch of different roles on Sentinels, but now you've kind of shifted over to a different role on Karmine Corp. You're pretty proficient with the attack OP as well. What's the difference between your form going into Champions this year as opposed to last year with Sentinels?</strong></p>
+<blockquote>
+<p>I mean, my form going into Champs last year was actually insanely good, to be honest. In the group stage of Stage 2, I [had] very good stats. I remember just dominating everybody and then [in] playoffs I definitely dipped off a bit.
+  I had two good games against NRG, but that was kind of the end of it. Overall, I was very confident going into Champs. But I think I was very sick during Champs 2025.
+  I was just very sick. I was not feeling good at all. So it was kind of hard for me to fully be engaged with the game.
+  I feel like I could have provided a lot more effort? Not effort. How would I say this? More value, I guess, provided more value to the team that I know I can do.
+  I think since coming to KC I've been playing a lot of Initiator. Then, I switched back onto kind of [a] Duelist role, especially on the start of SEN. Mainly, I'm just a confident OPer.
+  I know how good I am with the AWP. When I first started playing the game, I was just playing a lot of Chamber and stuff. So I think when Chamber is meta now again, I'm able to just translate my skills even better than I was because I was a worse player [before] and now I'm a better player and I know exactly what I can do with the agents.
+  I think going into this Champs, obviously, I think our form is really good. I hope the main thing for us is just to keep working hard and not really to think about the past.
+  We won the trophy. Yes, we can celebrate for today, but [we need] to keep moving forward and just try our best to keep the same system and continue to work hard and adapt to what we need to adapt to. I think we'll go into Champs with a very good form.</p>
+</blockquote>
+<p><strong>Are there any teams outside the EMEA that you want to play at Champs?</strong></p>
+<blockquote>
+<p>Obviously I want to play every team, to be honest. I respect everybody. And it's always fun to play against new players, old players, like old as in like they've been competing for a while, not elderly.</p>
+</blockquote>
+<p><strong>We got a couple of those in the league, though.</strong></p>
+<blockquote>
+<p>I mean, sociablEE. This guy's old and he's destroying completely. I mean, it's scary.
+  Like, you see that you see these uncs, but they're actually just shooting like babybay as well. I don't know. I don't know if they qualified to Champs yet.
+  I don't think they have. But it would be cool to play against these teams that I've played against, like NA teams. Obviously, I'm very experienced with playing against them, same with EMEA teams.
+  But most likely we focus on the group stage first. Obviously, Chinese teams are very not crazy, but their playstyle is so different from other regions. So it's always a cool game to play against them, and especially imagine playing against a Chinese team with the Chinese crowd. I think it'll be very, very entertaining. So I'm honestly hoping to play [against] any team.
+  If I had to pick specific ones, Paper Rex. Obviously they're [an] amazing team. TYLOO, very interesting. I don't think we can play them, though, because we're first and they're first seed as well because they won, so we can't play them. But I think EDG, any of these Chinese teams, I think would be very fun to play against.</p>
+</blockquote>
+<p><strong>You're one who – as a result of being part of SEN, a pretty big org with a lot of eyes on them – [has] drawn some criticism to yourself. I'm sure you might have noticed maybe when the results weren't that great. Is there anything you want to say to the haters or fans alike?</strong></p>
+<blockquote>
+<p>I mean, there's nothing really to say to the haters or fans. I think people on the internet just like to troll and people like to say everything that's on their mind on the internet nowadays. I feel like people don't really have [the] social skills or know what they're saying on the internet. Even I don't have that good of social skills, I would say. Like when I'm streaming on Twitch, sometimes I'm just saying stupid stuff all day, because I'm just saying what's on my mind. And to be honest, it's just like [that] on the internet, it's like that times 10 and people have no filter at all. And I don't think people are confident in what they're saying; they're confident [in] what they're saying, but they don't have all of the information.
+  So I think overall, if you see results are bad, they're going to hate. And if they see results are good, they're still going to hate. Nothing changes. People are going to hate you. People are going to love you. But at the end of the day, I'm still getting paid.</p>
+</blockquote>
+</div>
+</div></body></html>

--- a/tests/fixtures/news_750321.html
+++ b/tests/fixtures/news_750321.html
@@ -1,0 +1,106 @@
+<!doctype html><html><body><div class="wf-card mod-article">
+<div class="article-header">
+<a class="article-header-event" href="/event/2776/vct-2026-pacific-stage-2">
+<img src="//owcdn.net/img/640f5ae002674.png"/>
+<div>VCT 2026: Pacific Stage 2</div>
+</a>
+<h1 class="wf-title mod-article-title">
+			VARREL sent home as Global, T1 seal Champions Shanghai slots		</h1>
+<div class="article-meta">
+<div>
+<a class="article-meta-author" href="/user/jenopelle" style="margin-top: 2px;">jenopelle</a>
+<div>
+<time class="js-date-toggle" datetime="2026-09-05T00:10:51+05:30" title="Sep 5, 2026 at 00:10 IST">
+						1 day ago					</time>
+</div>
+</div>
+</div>
+</div>
+<div class="article-body">
+<style scoped="" type="text/css">
+</style>
+<p><a href="https://www.vlr.gg/event/2776/vct-2026-pacific-stage-2" target="_blank">VCT Pacific Stage 2</a> has kicked off its finals weekend action in Busan, with results sealing the region's four-team group that will head to <a href="https://www.vlr.gg/event/2766/valorant-champions-2026" target="_blank">Champions Shanghai</a>.</p>
+<p><span class="team" data-ref-id="0" style="display: inline-block; position: relative;">
+<a href="/team/11060/nongshim-redforce">
+<!--<i class="flag mod-kr"></i>-->
+		Nongshim RedForce	</a>
+
+</span> downed <span class="team" data-ref-id="1" style="display: inline-block; position: relative;">
+<a href="/team/918/global-esports">
+<!--<i class="flag mod-in"></i>-->
+		Global Esports	</a>
+
+</span> in three maps, but <span class="team" data-ref-id="2" style="display: inline-block; position: relative;">
+<a href="/team/14/t1">
+<!--<i class="flag mod-kr"></i>-->
+		T1	</a>
+
+</span>'s 2-0 win over <span class="team" data-ref-id="3" style="display: inline-block; position: relative;">
+<a href="/team/11229/varrel">
+<!--<i class="flag mod-jp"></i>-->
+		VARREL	</a>
+
+</span> meant that Global's ticket to Shanghai was punched on Championship Points at the very least. Here's a closer look at both matches:</p>
+<h1><a href="https://www.vlr.gg/742480/nongshim-redforce-vs-global-esports-vct-2026-pacific-stage-2-ubf" target="_blank">Nongshim continues to roll, downs Global Esports 2-1</a></h1>
+<p>This series began on Nongshim's pick of Haven, the team's most-played map in 2026. After some tweaking throughout the year, Nongshim returned to its Yoru-Neon comp with Killjoy as the Sentinel, a comp that it has gone 6-2 with on the map. Meanwhile, Global ran a double-Sentinel, Sage-Chamber comp on the map that may have been more associated with maps like Sunset. Early on, Global seemed to have the solution. A Nongshim pistol was followed by a GE eco, but the side struggled to make the most of it, losing its grip on Nongshim's opening attacker half.</p>
+<p>After entering halftime up 8-4, Nongshim won a key pistol to start the second half, which ended up becoming a 13-7 win on the map. GE seemed to plug and play its Sage-Chamber comp onto its pick of Ascent, while Nongshim made just one change heading into Ascent with <span class="team" data-ref-id="4" style="display: inline-block; position: relative;">
+<a href="/player/31829/ivy">
+		Ivy	</a>
+</span> on Cypher. Global started the map with some real dominance, seizing an early 6-2 lead that would end up having huge implications at the end of the map. </p>
+<p></p><div class="embed-spacing"></div><iframe allowfullscreen="true" class="twitch-embed" frameborder="0" scrolling="no" src="https://clips.twitch.tv/embed?clip=ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0&amp;parent=www.vlr.gg"></iframe>
+<em><span class="team" data-ref-id="5" style="display: inline-block; position: relative;">
+<a href="/player/31827/dambi">
+		Dambi	</a>
+</span> with a Dambi-esque 4K despite the loss on Ascent.</em>
+<p>Nongshim ended up steadying the ship to end its defender side, but those lost rounds in the first half ended up being the difference. GE settled into its defender side well despite serious heroics from Dambi, who ended up with 32 kills on the map, and the map ended up being an overtime victory for GE.</p>
+<p>The teams then moved to Abyss to decide the series. Abyss had been a sore spot in Nongshim's map pool that seemed to have finally been figured out, while GE looked solid on the map since its return to the pool. While both teams went with the "mosquito comp" pairing of Waylay-Yoru, GE went with a double-bubble smokes approach with <span class="team" data-ref-id="6" style="display: inline-block; position: relative;">
+<a href="/player/7754/xavi8k">
+		xavi8k	</a>
+</span> and <span class="team" data-ref-id="7" style="display: inline-block; position: relative;">
+<a href="/player/13744/patmen">
+		PatMen	</a>
+</span> on Astra and Yoru, while Nongshim continued with Ivy on Cypher.</p>
+<p>If Dambi was the standout performer in the loss on Ascent, <span class="team" data-ref-id="8" style="display: inline-block; position: relative;">
+<a href="/player/31828/francis">
+		Francis	</a>
+</span> was the standout on Abyss. He wreaked havoc, often being the early enforcer with a scoped sniper. He went 5-1 on defense, all while picking up eight Operator kills throughout the entire map. His early 12/2 start was central to NS's success, as a 4-0 lead was parlayed into an 8-4 halftime lead. Once again, Nongshim claimed a crucial pistol to inch towards closing things out, with a clean 13-6 to close out the series.</p>
+<p>Francis and Dambi dropped 59 and 58 kills to lead Nongshim to the win, while <span class="team" data-ref-id="9" style="display: inline-block; position: relative;">
+<a href="/player/872/autumn">
+		Autumn	</a>
+</span> led the way for GE with 52 of his own. While Nongshim seals its spot in Sunday's Grand Final, GE will compete in the Lower Final, with its slot at Champions Shanghai now secured thanks to the result of the second match of the day.</p>
+<h1><a href="https://www.vlr.gg/742486/varrel-vs-t1-vct-2026-pacific-stage-2-lr3" target="_blank">T1 derails the VARREL roll, seals Champions Shanghai spot with 2-0 win</a></h1>
+<p>While VARREL has been the story of Pacific since the beginning of Stage 2 with a miraculous turnaround, T1 has looked like the best version of itself in Stage 2. The series began on VARREL's Haven, a map that both teams have had mixed results on through Stage 2. While VARREL enjoyed early retake-fueled success on the map, T1 salvaged its attacker side by evening the score at 6 apiece entering halftime.</p>
+<p>On T1's defender side, proactive play and continued sharp reads from IGL <span class="team" data-ref-id="10" style="display: inline-block; position: relative;">
+<a href="/player/485/stax">
+		stax	</a>
+</span> helped T1 dominate, winning six of the first seven rounds of the half. While VARREL did claw back two rounds once T1 hit map point, T1 closed things out 13-9.</p>
+<p>All momentum was on T1's side entering its map pick of Lotus. T1 was yet to lose Lotus in Stage 2, playing with an Omen-Viper comp that has looked good, with <span class="team" data-ref-id="11" style="display: inline-block; position: relative;">
+<a href="/player/13039/meteor">
+		Meteor	</a>
+</span>'s Chamber a fundamental piece of it. Meanwhile, VARREL subbed out <span class="team" data-ref-id="12" style="display: inline-block; position: relative;">
+<a href="/player/4426/klaus">
+		Klaus	</a>
+</span> for <span class="team" data-ref-id="13" style="display: inline-block; position: relative;">
+<a href="/player/2149/c1nder">
+		C1ndeR	</a>
+</span> in the Controller role, a move that the team has gone on record in the past saying has been related to in-game comms.</p>
+<p>While T1's Lotus has been good, it would have been hard to predict that it was this good. It was utter domination early on, with Meteor the usual suspect once again. He had a 10/1 start to the map, which fueled an 11-0 open to the map for T1. VARREL pulled off a slow-roll hit onto the A site to claim one attack-side round, which appeared to be the start it needed to start on defense. With its season two round losses away from ending, VARREL looked to flip the script, winning six straight rounds to start its own defensive side and get to within four rounds of T1. From there though, a well-worked round from T1 saw the side toy with both ends of the map before ending on B, resulting in a round won to reach match point.</p>
+<p>VARREL used pressure to control T1 on the map, resulting in two rounds claimed at the death. Despite the run, it was too little, too late for VARREL, as T1 shut down the comeback attempt at 13-9.</p>
+<p></p><div class="embed-spacing"></div><iframe allowfullscreen="true" class="twitch-embed" frameborder="0" scrolling="no" src="https://clips.twitch.tv/embed?clip=SweetGentleNuggetsDeIlluminati-2JNyv9VccGOXTrcV&amp;parent=www.vlr.gg"></iframe>
+<em>Meteor finished the series on his own terms.</em>
+<p>Meteor's impact in the series was immense, as he was the only player to drop more than 30 kills with a series-high 40. <span class="team" data-ref-id="14" style="display: inline-block; position: relative;">
+<a href="/player/804/buzz">
+		BuZz	</a>
+</span> continued to be the first engagement specialist for T1, taking part in 16 first engagements to drop 30 kills. <span class="team" data-ref-id="15" style="display: inline-block; position: relative;">
+<a href="/player/34926/oonzmlp">
+		oonzmlp	</a>
+</span> had a team-high 29 kills for VL, which did not end up being enough. </p>
+<h1>Up next</h1>
+<p>Three teams remain in Stage 2, with all three already having their Champions Shanghai slots sealed. While Nongshim gets a day off thanks to its Upper Final win, Global Esports and T1 will battle it out in their first-ever playoff meeting for the chance at a spot in the Grand Final.</p>
+<p>VCT Pacific Stage 2 will finish with the following matches:</p>
+<ul>
+<li><a href="https://www.vlr.gg/742487/global-esports-vs-t1-vct-2026-pacific-stage-2-lbf" target="_blank">Global Esports vs. T1</a> <em>(Lower Final))</em></li>
+<li><a href="https://www.vlr.gg/742481/nongshim-redforce-vs-tbd-vct-2026-pacific-stage-2-gf" target="_blank">Nongshim RedForce vs. GE/T1</a> <em>(Grand Final)</em></li>
+</ul>
+</div>
+</div></body></html>

--- a/tests/fixtures/news_750541.html
+++ b/tests/fixtures/news_750541.html
@@ -1,0 +1,95 @@
+<!doctype html><html><body><div class="wf-card mod-article">
+<div class="article-header">
+<h1 class="wf-title mod-article-title">
+			Team Heretics releases koshmaras		</h1>
+<div class="article-meta">
+<div>
+<a class="article-meta-author" href="/user/jenopelle" style="margin-top: 2px;">jenopelle</a>
+<div>
+<time class="js-date-toggle" datetime="2026-09-05T01:51:50+05:30" title="Sep 5, 2026 at 01:51 IST">
+						22 hours ago					</time>
+</div>
+</div>
+</div>
+</div>
+<div class="article-body">
+<style scoped="" type="text/css">
+</style>
+<p><span class="team" data-ref-id="0" style="display: inline-block; position: relative;">
+<a href="/team/1001/team-heretics">
+<!--<i class="flag mod-eu"></i>-->
+		Team Heretics	</a>
+
+</span> has <a href="https://x.com/HereticsVal/status/2095874986753900564" target="_blank">released</a> <span class="team" data-ref-id="1" style="display: inline-block; position: relative; white-space: nowrap;">Martynas		"<a href="/player/23365/koshmaras">koshmaras</a>"
+		Namikas</span> Duelist player, ending his stay with the team after less than five months together.</p>
+<p>The move, which is still pending Riot approval, is believed to be by way of mutual termination, as koshmaras had a contract with Heretics running through the 2028 season.</p>
+<p><img alt="koshmaras getting ready to lift the EMEA Stage 1 trophy." src="//owcdn.net/img/6a9b276b7e86b.jpg"/>
+<em>koshmaras getting ready to lift the EMEA Stage 1 trophy. (Photo by Wojciech Wandzel/Riot Games).</em></p>
+<p>Earlier this week, TH's in-game leader <span class="team" data-ref-id="2" style="display: inline-block; position: relative;">
+<a href="/player/1144/boo">
+		Boo	</a>
+</span> was allowed to <a href="https://www.vlr.gg/749695/boo-ends-four-year-run-with-team-heretics" target="_blank">explore his options</a>, with his contract set to expire this offseason.</p>
+<p>"It was a really amazing experience, big [heart] to my teammates and staff that I basically became [with] friends for life," koshmaras <a href="https://x.com/koshmaras2/status/2095899983962636358" target="_blank">said</a>. "For the fans that believed in me and showed support THANK YOU!"</p>
+<p>koshmaras's move to Heretics was well-documented, as the team was very transparent in sharing its process behind a mid-<a href="https://www.vlr.gg/event/2863/vct-2026-emea-stage-1/group-stage" target="_blank">Stage 1</a> move on from <span class="team" data-ref-id="3" style="display: inline-block; position: relative;">
+<a href="/player/40591/comeback">
+		ComeBack	</a>
+</span>. He joined after just two matches played for <span class="team" data-ref-id="4" style="display: inline-block; position: relative;">
+<a href="/team/17179/dnsty">
+<!--<i class="flag mod-it"></i>-->
+		DNSTY	</a>
+
+</span>, and has also previously played for <span class="team" data-ref-id="5" style="display: inline-block; position: relative;">
+<a href="/team/21497/agent-x">
+<!--<i class="flag mod-un"></i>-->
+		Agent X	</a>
+
+</span>, <span class="team" data-ref-id="6" style="display: inline-block; position: relative;">
+<a href="/team/19190/6gpa">
+<!--<i class="flag mod-de"></i>-->
+		6GPA	</a>
+
+</span>, <span class="team" data-ref-id="7" style="display: inline-block; position: relative;">
+<a href="/team/16397/leo-esports">
+<!--<i class="flag mod-se"></i>-->
+		LEO Esports	</a>
+
+</span>, <span class="team" data-ref-id="8" style="display: inline-block; position: relative;">
+<a href="/team/14435/vultures">
+<!--<i class="flag mod-un"></i>-->
+		Vultures	</a>
+
+</span>, and <span class="team" data-ref-id="9" style="display: inline-block; position: relative;">
+<a href="/team/7462/aboveclouds">
+<!--<i class="flag mod-eu"></i>-->
+		AboveClouds	</a>
+
+</span>. </p>
+<p>With Team Heretics, koshmaras played a central role as a primary Neon player, helping lead Heretics to a trophy-lifting Stage 1 run. The run helped the team qualify for <a href="https://www.vlr.gg/event/2765/valorant-masters-london-2026" target="_blank">Masters London</a>, which ended with a 7th-8th finish for the org after earning a bye into the playoffs. Heretics experimented in <a href="https://www.vlr.gg/event/2976/vct-2026-emea-stage-2/play-ins" target="_blank">Stage 2</a> with koshmaras on other agents like Phoenix and Omen, but struggled for results. The team ended the year ranked 11th-12th in EMEA, and far below the threshold to qualify for <a href="https://www.vlr.gg/event/2766/valorant-champions-2026" target="_blank">Champions Shanghai</a> on points.</p>
+<p><span class="team" data-ref-id="10" style="display: inline-block; position: relative;">
+<a href="/team/1001/team-heretics">
+<!--<i class="flag mod-eu"></i>-->
+		Team Heretics	</a>
+
+</span>'s full active roster is now:</p>
+<ul>
+<li><i class="flag mod-tr"></i> <span class="team" data-ref-id="11" style="display: inline-block; position: relative; white-space: nowrap;">Enes		"<a href="/player/10971/riens">RieNs</a>"
+		Ecirli</span> </li>
+<li><i class="flag mod-tr"></i> <span class="team" data-ref-id="12" style="display: inline-block; position: relative; white-space: nowrap;">Mert		"<a href="/player/21328/wo0t">Wo0t</a>"
+		Alkan</span> </li>
+<li><i class="flag mod-gb"></i> <span class="team" data-ref-id="13" style="display: inline-block; position: relative; white-space: nowrap;">Benjamin		"<a href="/player/29873/benjyfishy">benjyfishy</a>"
+		David Fish</span> </li>
+<li><i class="flag mod-de"></i> <span class="team" data-ref-id="14" style="display: inline-block; position: relative; white-space: nowrap;">Niklas		"<a href="/player/46268/niklas">Niklas</a>"
+		Geiss</span> <em>(Manager)</em></li>
+<li><i class="flag mod-at"></i> <span class="team" data-ref-id="15" style="display: inline-block; position: relative; white-space: nowrap;">Daniel		"<a href="/player/61338/copper">Copper</a>"
+		Blaimauer</span> <em>(Manager)</em></li>
+<li><i class="flag mod-gb"></i> <span class="team" data-ref-id="16" style="display: inline-block; position: relative; white-space: nowrap;">Neil		"<a href="/player/2039/neilzinho">neilzinho</a>"
+		Finlay</span> <em>(Head coach)</em></li>
+<li><i class="flag mod-gb"></i> <span class="team" data-ref-id="17" style="display: inline-block; position: relative; white-space: nowrap;">Brandon		"<a href="/player/2038/weber">weber</a>"
+		Weber</span> <em>(Coach)</em></li>
+<li><i class="flag mod-wa"></i> <span class="team" data-ref-id="18" style="display: inline-block; position: relative; white-space: nowrap;">Robert		"<a href="/player/61337/rob">Rob</a>"
+		William Davies</span> <em>(Performance coach)</em></li>
+<li><i class="flag mod-de"></i> <span class="team" data-ref-id="19" style="display: inline-block; position: relative; white-space: nowrap;">Benedikt		"<a href="/player/62235/beni">Beni</a>"
+		Baumann</span> <em>(Analyst)</em></li>
+</ul>
+</div>
+</div></body></html>

--- a/tests/golden/test_live_golden/news_562934.yml
+++ b/tests/golden/test_live_golden/news_562934.yml
@@ -4,6 +4,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs:
   - bold: false
     italic: false
@@ -36,6 +37,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs:
   - bold: false
     italic: false
@@ -74,6 +76,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs:
   - bold: false
     italic: false
@@ -103,6 +106,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs: []
   start: 1
   type: image
@@ -111,6 +115,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs:
   - bold: false
     italic: true
@@ -124,6 +129,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs:
   - bold: false
     italic: false
@@ -163,6 +169,7 @@ blocks:
   children: []
   level: null
   ordered: false
+  player: null
   runs:
   - bold: false
     italic: false
@@ -183,6 +190,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -201,6 +209,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -211,6 +220,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -229,6 +239,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -239,6 +250,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -257,6 +269,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -267,6 +280,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -285,6 +299,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -295,6 +310,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -313,6 +329,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -323,6 +340,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -341,6 +359,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -351,6 +370,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -373,6 +393,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -383,6 +404,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -405,6 +427,7 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
@@ -415,6 +438,7 @@ blocks:
       children: []
       level: null
       ordered: false
+      player: null
       runs:
       - bold: false
         italic: false
@@ -437,12 +461,14 @@ blocks:
       url: null
     level: null
     ordered: false
+    player: null
     runs: []
     start: 1
     type: list_item
     url: null
   level: null
   ordered: false
+  player: null
   runs: []
   start: 1
   type: list

--- a/tests/golden/test_live_golden/news_562934.yml
+++ b/tests/golden/test_live_golden/news_562934.yml
@@ -3,6 +3,7 @@ blocks:
 - alt: ''
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs:
@@ -36,6 +37,7 @@ blocks:
 - alt: ''
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs:
@@ -75,6 +77,7 @@ blocks:
 - alt: ''
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs:
@@ -105,6 +108,7 @@ blocks:
 - alt: Muggle holding Champions 2024 trophy
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs: []
@@ -114,6 +118,7 @@ blocks:
 - alt: ''
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs:
@@ -128,6 +133,7 @@ blocks:
 - alt: ''
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs:
@@ -168,6 +174,7 @@ blocks:
 - alt: ''
   children: []
   level: null
+  link_url: null
   ordered: false
   player: null
   runs:
@@ -189,6 +196,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -208,6 +216,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -219,6 +228,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -238,6 +248,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -249,6 +260,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -268,6 +280,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -279,6 +292,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -298,6 +312,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -309,6 +324,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -328,6 +344,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -339,6 +356,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -358,6 +376,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -369,6 +388,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -392,6 +412,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -403,6 +424,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -426,6 +448,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -437,6 +460,7 @@ blocks:
     - alt: ''
       children: []
       level: null
+      link_url: null
       ordered: false
       player: null
       runs:
@@ -460,6 +484,7 @@ blocks:
       type: paragraph
       url: null
     level: null
+    link_url: null
     ordered: false
     player: null
     runs: []
@@ -467,6 +492,7 @@ blocks:
     type: list_item
     url: null
   level: null
+  link_url: null
   ordered: false
   player: null
   runs: []

--- a/tests/golden/test_live_golden/news_562934.yml
+++ b/tests/golden/test_live_golden/news_562934.yml
@@ -1,4 +1,452 @@
 author: raezeri
+blocks:
+- alt: ''
+  children: []
+  level: null
+  ordered: false
+  runs:
+  - bold: false
+    italic: false
+    text: 'EDward Gaming '
+    url: https://www.vlr.gg/team/1120/edward-gaming
+  - bold: false
+    italic: false
+    text: 'has '
+    url: null
+  - bold: false
+    italic: false
+    text: announced
+    url: https://x.com/EDG_Edward/status/1972982254118080940
+  - bold: false
+    italic: false
+    text: ' the departure of head coach Tang "'
+    url: null
+  - bold: false
+    italic: false
+    text: Muggle
+    url: https://www.vlr.gg/player/29401/muggle
+  - bold: false
+    italic: false
+    text: '" Shijun (唐时俊).'
+    url: null
+  start: 1
+  type: paragraph
+  url: null
+- alt: ''
+  children: []
+  level: null
+  ordered: false
+  runs:
+  - bold: false
+    italic: false
+    text: Muggle's long tenure with the team began back in 2022, when he joined as
+      a coach under previous head coach Lo "
+    url: null
+  - bold: false
+    italic: false
+    text: AfteR
+    url: https://www.vlr.gg/player/8643/after
+  - bold: false
+    italic: false
+    text: '" Wen-Hsin (罗文信). Following disappointing losses for EDG at '
+    url: null
+  - bold: false
+    italic: false
+    text: Masters Shanghai
+    url: https://www.vlr.gg/event/1999/champions-tour-2024-masters-shanghai/playoffs
+  - bold: false
+    italic: false
+    text: ' and the beginning of '
+    url: null
+  - bold: false
+    italic: false
+    text: Stage 2
+    url: https://www.vlr.gg/event/2499/vct-2025-china-stage-2/group-stage
+  - bold: false
+    italic: false
+    text: ' in 2024, AfteR was moved to an inactive role, leaving Muggle to take up
+      the mantle of head coach in his stead.'
+    url: null
+  start: 1
+  type: paragraph
+  url: null
+- alt: ''
+  children: []
+  level: null
+  ordered: false
+  runs:
+  - bold: false
+    italic: false
+    text: With the addition of Hsien "
+    url: null
+  - bold: false
+    italic: false
+    text: S1Mon
+    url: https://www.vlr.gg/player/13768/s1mon
+  - bold: false
+    italic: false
+    text: '" Meng-Hsun (谢孟勋) at the same time and Muggle at the helm, EDG went on
+      to make history two months later by winning China''s first global title at '
+    url: null
+  - bold: false
+    italic: false
+    text: Champions 2024
+    url: https://www.vlr.gg/event/2097/valorant-champions-2024
+  - bold: false
+    italic: false
+    text: .
+    url: null
+  start: 1
+  type: paragraph
+  url: null
+- alt: Muggle holding Champions 2024 trophy
+  children: []
+  level: null
+  ordered: false
+  runs: []
+  start: 1
+  type: image
+  url: https://owcdn.net/img/68dc50c179615.jpg
+- alt: ''
+  children: []
+  level: null
+  ordered: false
+  runs:
+  - bold: false
+    italic: true
+    text: One of the first from China to lift an international trophy. (Photo by Colin
+      Young-Wolff/Riot Games)
+    url: null
+  start: 1
+  type: caption
+  url: null
+- alt: ''
+  children: []
+  level: null
+  ordered: false
+  runs:
+  - bold: false
+    italic: false
+    text: '2025 was a more challenging year for EDG. After placing third at '
+    url: null
+  - bold: false
+    italic: false
+    text: Masters Bangkok
+    url: https://www.vlr.gg/event/2281/valorant-masters-bangkok-2025
+  - bold: false
+    italic: false
+    text: ', the team struggled to return to the top, missing out on an international
+      event for the first time when they failed to qualify to Masters Toronto with
+      a fourth-place domestic finish in '
+    url: null
+  - bold: false
+    italic: false
+    text: Stage 1
+    url: https://www.vlr.gg/event/2359/vct-2025-china-stage-1/playoffs
+  - bold: false
+    italic: false
+    text: '. The defending champions managed to return to the global stage for '
+    url: null
+  - bold: false
+    italic: false
+    text: Champions 2025
+    url: https://www.vlr.gg/event/2283/valorant-champions-2025/group-stage
+  - bold: false
+    italic: false
+    text: ' as China''s third seed, but their run ended early with a winless exit
+      in the group stage, bringing an end to their season.'
+    url: null
+  start: 1
+  type: paragraph
+  url: null
+- alt: ''
+  children: []
+  level: null
+  ordered: false
+  runs:
+  - bold: false
+    italic: false
+    text: 'EDward Gaming '
+    url: https://www.vlr.gg/team/1120/edward-gaming
+  - bold: false
+    italic: false
+    text: 'is currently:'
+    url: null
+  start: 1
+  type: paragraph
+  url: null
+- alt: ''
+  children:
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Wang "
+        url: null
+      - bold: false
+        italic: false
+        text: nobody
+        url: https://www.vlr.gg/player/3017/nobody
+      - bold: false
+        italic: false
+        text: '" Senxu (王森旭)'
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Zheng "
+        url: null
+      - bold: false
+        italic: false
+        text: ZmjjKK
+        url: https://www.vlr.gg/player/3520/zmjjkk
+      - bold: false
+        italic: false
+        text: '" Yongkang (郑永康)'
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Wan "
+        url: null
+      - bold: false
+        italic: false
+        text: CHICHOO
+        url: https://www.vlr.gg/player/15559/chichoo
+      - bold: false
+        italic: false
+        text: '" Shunzhi (万顺治)'
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Zhang "
+        url: null
+      - bold: false
+        italic: false
+        text: Smoggy
+        url: https://www.vlr.gg/player/4742/smoggy
+      - bold: false
+        italic: false
+        text: '" Zhao (张钊)'
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Zhang "
+        url: null
+      - bold: false
+        italic: false
+        text: Jieni7
+        url: https://www.vlr.gg/player/51244/jieni7
+      - bold: false
+        italic: false
+        text: '" Juntai (张君泰)'
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Zhang "
+        url: null
+      - bold: false
+        italic: false
+        text: zjc
+        url: https://www.vlr.gg/player/7135/zjc
+      - bold: false
+        italic: false
+        text: '" Juncheng (张峻程)'
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Shou "
+        url: null
+      - bold: false
+        italic: false
+        text: Aqua
+        url: https://www.vlr.gg/player/38828/aqua
+      - bold: false
+        italic: false
+        text: '" Wenjun (寿文君) '
+        url: null
+      - bold: false
+        italic: true
+        text: (Manager)
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Chen "
+        url: null
+      - bold: false
+        italic: false
+        text: heav1n
+        url: https://www.vlr.gg/player/51243/heav1n
+      - bold: false
+        italic: false
+        text: '" Wang '
+        url: null
+      - bold: false
+        italic: true
+        text: (Assistant coach)
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  - alt: ''
+    children:
+    - alt: ''
+      children: []
+      level: null
+      ordered: false
+      runs:
+      - bold: false
+        italic: false
+        text: Li "
+        url: null
+      - bold: false
+        italic: false
+        text: JuiceFlip
+        url: https://www.vlr.gg/player/45810/juiceflip
+      - bold: false
+        italic: false
+        text: '" Junsheng (李俊升) '
+        url: null
+      - bold: false
+        italic: true
+        text: (Staff)
+        url: null
+      start: 1
+      type: paragraph
+      url: null
+    level: null
+    ordered: false
+    runs: []
+    start: 1
+    type: list_item
+    url: null
+  level: null
+  ordered: false
+  runs: []
+  start: 1
+  type: list
+  url: null
 content: '{{link_0}} has {{link_1}} the departure of head coach Tang "{{link_2}}"
   Shijun (唐时俊).
 
@@ -13,6 +461,9 @@ content: '{{link_0}} has {{link_1}} the departure of head coach Tang "{{link_2}}
   With the addition of Hsien "{{link_6}}" Meng-Hsun (谢孟勋) at the same time and Muggle
   at the helm, EDG went on to make history two months later by winning China''s first
   global title at {{link_7}}.
+
+
+  {image_0}
 
 
   One of the first from China to lift an international trophy. (Photo by Colin Young-Wolff/Riot
@@ -30,26 +481,23 @@ content: '{{link_0}} has {{link_1}} the departure of head coach Tang "{{link_2}}
   {{link_11}} is currently:
 
 
-  -  Wang "{{link_12}}" Senxu (王森旭)
+  - Wang "{{link_12}}" Senxu (王森旭)
 
-  -  Zheng "{{link_13}}" Yongkang (郑永康)
+  - Zheng "{{link_13}}" Yongkang (郑永康)
 
-  -  Wan "{{link_14}}" Shunzhi (万顺治)
+  - Wan "{{link_14}}" Shunzhi (万顺治)
 
-  -  Zhang "{{link_15}}" Zhao (张钊)
+  - Zhang "{{link_15}}" Zhao (张钊)
 
-  -  Zhang "{{link_16}}" Juntai (张君泰)
+  - Zhang "{{link_16}}" Juntai (张君泰)
 
-  -  Zhang "{{link_17}}" Juncheng (张峻程)
+  - Zhang "{{link_17}}" Juncheng (张峻程)
 
-  -  Shou "{{link_18}}" Wenjun (寿文君) (Manager)
+  - Shou "{{link_18}}" Wenjun (寿文君) (Manager)
 
-  -  Chen "{{link_19}}" Wang (Assistant coach)
+  - Chen "{{link_19}}" Wang (Assistant coach)
 
-  -  Li "{{link_20}}" Junsheng (李俊升) (Staff)
-
-
-  {image_0}'
+  - Li "{{link_20}}" Junsheng (李俊升) (Staff)'
 date: <date>
 id: '562934'
 images:

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,36 @@
+from urllib.parse import parse_qs, urlsplit
+
+from bs4 import BeautifulSoup
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+
+
+def test_public_player_uses_its_own_origin_and_rejects_invalid_media(monkeypatch):
+    monkeypatch.setattr(settings, "API_KEYS", {"test": "test-key"})
+    from app.main import app
+
+    client = TestClient(app, base_url="https://api.example.test:8443")
+    for provider, media_id in [("youtube", "vbBd_Hu6o2M"), ("twitch", "ExampleClip-123")]:
+        response = client.get(f"/media/{provider}/{media_id}")
+        assert response.status_code == 200
+        iframe = BeautifulSoup(response.text, "html.parser").find("iframe")
+        source = urlsplit(iframe["src"])
+        query = parse_qs(source.query)
+        if provider == "youtube":
+            assert source.hostname == "www.youtube.com"
+            assert source.path == "/embed/vbBd_Hu6o2M"
+            assert query == {"origin": ["https://api.example.test:8443"], "playsinline": ["1"], "autoplay": ["0"]}
+        else:
+            assert source.hostname == "clips.twitch.tv"
+            assert query == {"clip": ["ExampleClip-123"], "parent": ["api.example.test"], "autoplay": ["false"]}
+        minimum = "min-width:200px;min-height:200px" if provider == "youtube" else "min-width:400px;min-height:300px"
+        assert minimum in response.text
+        assert iframe.has_attr("allowfullscreen")
+        assert iframe["referrerpolicy"] == "strict-origin-when-cross-origin"
+        assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+        assert "default-src 'none'" in response.headers["content-security-policy"]
+    for path in ["other/ExampleClip", "youtube/short", "twitch/%22%3E%3Cscript%3E"]:
+        response = client.get(f"/media/{path}")
+        assert response.status_code == 404
+        assert "<script>" not in response.text

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from app.core.config import settings
 
 
-def test_public_player_uses_its_own_origin_and_rejects_invalid_media(monkeypatch):
+def test_public_player_endpoint_contract_and_invalid_media(monkeypatch):
     monkeypatch.setattr(settings, "API_KEYS", {"test": "test-key"})
     from app.main import app
 
@@ -15,12 +15,15 @@ def test_public_player_uses_its_own_origin_and_rejects_invalid_media(monkeypatch
         response = client.get(f"/media/{provider}/{media_id}")
         assert response.status_code == 200
         iframe = BeautifulSoup(response.text, "html.parser").find("iframe")
-        source = urlsplit(iframe["src"])
+        assert iframe is not None
+        src = iframe["src"]
+        assert isinstance(src, str)
+        source = urlsplit(src)
         query = parse_qs(source.query)
         if provider == "youtube":
             assert source.hostname == "www.youtube.com"
             assert source.path == "/embed/vbBd_Hu6o2M"
-            assert query == {"origin": ["https://api.example.test:8443"], "playsinline": ["1"], "autoplay": ["0"]}
+            assert query == {"playsinline": ["1"], "autoplay": ["0"]}
         else:
             assert source.hostname == "clips.twitch.tv"
             assert query == {"clip": ["ExampleClip-123"], "parent": ["api.example.test"], "autoplay": ["false"]}
@@ -30,7 +33,6 @@ def test_public_player_uses_its_own_origin_and_rejects_invalid_media(monkeypatch
         assert iframe["referrerpolicy"] == "strict-origin-when-cross-origin"
         assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
         assert "default-src 'none'" in response.headers["content-security-policy"]
-    for path in ["other/ExampleClip", "youtube/short", "twitch/%22%3E%3Cscript%3E"]:
-        response = client.get(f"/media/{path}")
-        assert response.status_code == 404
-        assert "<script>" not in response.text
+    response = client.get("/media/twitch/%22%3E%3Cscript%3E")
+    assert response.status_code == 404
+    assert "<script>" not in response.text

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -38,17 +39,88 @@ async def test_news_list_does_not_return_partial_results(http_get):
 
 
 @pytest.mark.asyncio
-async def test_news_article_preserves_links_and_quoted_names(http_response):
+@pytest.mark.parametrize("article_id", ["562934", "750541", "748106", "750321"])
+async def test_news_article_preserves_links_and_quoted_names(http_response, article_id):
     response = http_response(
-        "https://www.vlr.gg/562934",
-        (FIXTURE_DIR / "news_562934.html").read_bytes(),
+        f"https://www.vlr.gg/{article_id}",
+        (FIXTURE_DIR / f"news_{article_id}.html").read_bytes(),
     )
 
     with patch("httpx.AsyncClient.get", return_value=response):
-        result = await news.news_by_id("562934")
+        result = await news.news_by_id(article_id)
 
-    assert result.title == "EDward Gaming bids farewell to head coach Muggle"
-    assert 'Tang "{{link_2}}" Shijun' in result.content
-    assert len(result.links) == 21
-    assert len(result.images) == 1
-    assert result.author == "raezeri"
+    text = re.sub(r"\{\{link_(\d+)\}\}", lambda m: result.links[int(m[1])]["text"], result.content)
+    if article_id == "562934":
+        assert result.title == "EDward Gaming bids farewell to head coach Muggle"
+        assert 'Tang "{{link_2}}" Shijun' in result.content
+        assert len(result.links) == 21
+        assert len(result.images) == 1
+        assert result.author == "raezeri"
+        assert text.index("{image_0}") < text.index("One of the first from China") < text.index("2025 was")
+        assert result.blocks[-1].type == "list"
+        assert len(result.blocks[-1].children) == 9
+    elif article_id == "750541":
+        assert text.index("2028 season.") < text.index("{image_0}") < text.index("koshmaras getting ready")
+        assert [b.type for b in result.blocks[:4]] == ["paragraph", "paragraph", "image", "caption"]
+        assert any(r.italic for r in result.blocks[3].runs)
+        assert result.blocks[-1].type == "list"
+        assert len(result.blocks[-1].children) == 9
+    elif article_id == "748106":
+        assert text.index("{video_0}") < text.index("N4RRATE, it's been a year")
+        assert [b.type for b in result.blocks[:4]] == ["paragraph", "video", "paragraph", "blockquote"]
+        assert all(r.italic for r in result.blocks[0].runs)
+        assert all(r.bold for r in result.blocks[2].runs)
+        assert len([b for b in result.blocks if b.type == "blockquote"]) == 6
+        assert text.count("It's definitely been like a bit of a roller coaster") == 1
+    else:
+        headings = [b for b in result.blocks if b.type == "heading"]
+        assert ["".join(r.text for r in h.runs) for h in headings] == [
+            "Nongshim continues to roll, downs Global Esports 2-1",
+            "T1 derails the VARREL roll, seals Champions Shanghai spot with 2-0 win",
+            "Up next",
+        ]
+        assert all(h.level == 1 for h in headings)
+        assert text.index("{video_0}") < text.index("Dambi with a Dambi-esque")
+        assert text.index("{video_1}") < text.index("Meteor finished the series")
+        assert text.count("Up next") == 1
+
+    assert result.blocks
+    assert "{{image_" not in result.content
+    assert "{{video_" not in result.content
+    assert len(re.findall(r"\{image_\d+\}", result.content)) == len(result.images)
+    assert len(re.findall(r"\{video_\d+\}", result.content)) == len(result.videos)
+
+
+@pytest.mark.asyncio
+async def test_news_article_fallback_preserves_nested_content_once(http_response):
+    response = http_response(
+        "https://www.vlr.gg/1",
+        b"""
+        <html><head><title>Fallback article</title></head><body><article>
+          <p>pre<a href="/player/1"><strong>bold<em>both</em></strong></a>post<br>next</p>
+          <ol start="3"><li>Outer<ul><li>Inner</li></ul>Tail</li><li>Second</li></ol>
+          <figure><a href="/photo"><img src="//owcdn.net/photo.jpg" alt="Winner"></a>
+            <figcaption>Photo <em>credit</em></figcaption></figure>
+          <video><source src="/clip.mp4"></video><p>After video</p>
+          <script>hidden script</script><!-- hidden comment -->
+        </article></body></html>""",
+    )
+    with patch("httpx.AsyncClient.get", return_value=response):
+        result = await news.news_by_id("1")
+
+    assert result.title == "Fallback article"
+    assert [b.type for b in result.blocks] == ["paragraph", "list", "image", "caption", "video", "paragraph"]
+    paragraph, ordered, image, caption, video, _ = result.blocks
+    assert "".join(r.text for r in paragraph.runs) == "preboldbothpost\nnext"
+    linked = [r for r in paragraph.runs if r.url]
+    assert [(r.text, r.bold, r.italic) for r in linked] == [("bold", True, False), ("both", True, True)]
+    assert all(r.url == "https://www.vlr.gg/player/1" for r in linked)
+    assert ordered.ordered and ordered.start == 3
+    assert [b.type for b in ordered.children[0].children] == ["paragraph", "list", "paragraph"]
+    assert len(ordered.children) == 2
+    assert image.url == "https://owcdn.net/photo.jpg" and image.alt == "Winner"
+    assert caption.runs[-1].italic
+    assert video.url == "https://www.vlr.gg/clip.mp4"
+    assert result.content.count("After video") == 1
+    assert "hidden" not in result.content
+    assert result.links == [{"text": "boldboth", "url": "https://www.vlr.gg/player/1"}]

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -68,6 +68,14 @@ async def test_news_article_preserves_links_and_quoted_names(http_response, arti
     elif article_id == "748106":
         assert text.index("{video_0}") < text.index("N4RRATE, it's been a year")
         assert [b.type for b in result.blocks[:4]] == ["paragraph", "video", "paragraph", "blockquote"]
+        player = result.blocks[1].player
+        assert player is not None
+        assert player.model_dump() == {
+            "provider": "youtube",
+            "media_id": "vbBd_Hu6o2M",
+            "player_url": "/media/youtube/vbBd_Hu6o2M",
+            "external_url": "https://www.youtube.com/watch?v=vbBd_Hu6o2M",
+        }
         assert all(r.italic for r in result.blocks[0].runs)
         assert all(r.bold for r in result.blocks[2].runs)
         assert len([b for b in result.blocks if b.type == "blockquote"]) == 6
@@ -83,6 +91,12 @@ async def test_news_article_preserves_links_and_quoted_names(http_response, arti
         assert text.index("{video_0}") < text.index("Dambi with a Dambi-esque")
         assert text.index("{video_1}") < text.index("Meteor finished the series")
         assert text.count("Up next") == 1
+        videos = [b for b in result.blocks if b.type == "video"]
+        assert all(b.player is not None and b.player.provider == "twitch" for b in videos)
+        assert videos[0].player.media_id == "ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0"
+        assert (
+            videos[0].player.external_url == "https://clips.twitch.tv/ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0"
+        )
 
     assert result.blocks
     assert "{{image_" not in result.content
@@ -121,6 +135,38 @@ async def test_news_article_fallback_preserves_nested_content_once(http_response
     assert image.url == "https://owcdn.net/photo.jpg" and image.alt == "Winner"
     assert caption.runs[-1].italic
     assert video.url == "https://www.vlr.gg/clip.mp4"
+    assert video.player is None
     assert result.content.count("After video") == 1
     assert "hidden" not in result.content
     assert result.links == [{"text": "boldboth", "url": "https://www.vlr.gg/player/1"}]
+
+
+@pytest.mark.asyncio
+async def test_news_video_links_only_embed_supported_providers(http_response):
+    accepted = [
+        "https://youtube.com/watch?v=vbBd_Hu6o2M",
+        "https://youtu.be/vbBd_Hu6o2M",
+        "https://www.youtube-nocookie.com/embed/vbBd_Hu6o2M",
+        "https://clips.twitch.tv/ExampleClip",
+        "https://www.twitch.tv/valorant/clip/ExampleClip",
+    ]
+    rejected = [
+        "https://youtube.com.evil.test/embed/vbBd_Hu6o2M",
+        "https://www.youtube.com/embed/invalid",
+        "https://clips.twitch.tv/embed?clip=%22%3E%3Cscript%3E",
+        "https://youtube.com@evil.test/embed/vbBd_Hu6o2M",
+    ]
+    html = "<article>" + "".join(f'<iframe src="{url}"></iframe>' for url in accepted + rejected) + "</article>"
+    with patch("httpx.AsyncClient.get", return_value=http_response("https://www.vlr.gg/1", html.encode())):
+        result = await news.news_by_id("1")
+    assert [b.player.provider if b.player else None for b in result.blocks] == [
+        "youtube",
+        "youtube",
+        "youtube",
+        "twitch",
+        "twitch",
+        None,
+        None,
+        None,
+        None,
+    ]

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -70,7 +70,7 @@ async def test_news_article_preserves_links_and_quoted_names(http_response, arti
         assert [b.type for b in result.blocks[:4]] == ["paragraph", "video", "paragraph", "blockquote"]
         player = result.blocks[1].player
         assert player is not None
-        assert player.model_dump() == {
+        assert player.model_dump(mode="json") == {
             "provider": "youtube",
             "media_id": "vbBd_Hu6o2M",
             "player_url": "/media/youtube/vbBd_Hu6o2M",
@@ -93,10 +93,13 @@ async def test_news_article_preserves_links_and_quoted_names(http_response, arti
         assert text.count("Up next") == 1
         videos = [b for b in result.blocks if b.type == "video"]
         assert all(b.player is not None and b.player.provider == "twitch" for b in videos)
-        assert videos[0].player.media_id == "ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0"
-        assert (
-            videos[0].player.external_url == "https://clips.twitch.tv/ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0"
-        )
+        player = videos[0].player
+        assert player is not None
+        assert player.media_id == "ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0"
+        assert player.external_url == "https://clips.twitch.tv/ExquisiteRealSandpiperBabyRage-31jlkIQddWpcEqu0"
+        video_indexes = [index for index, block in enumerate(result.blocks) if block.type == "video"]
+        assert [result.blocks[index + 1].type for index in video_indexes] == ["caption", "caption"]
+        assert all(all(run.italic for run in result.blocks[index + 1].runs) for index in video_indexes)
 
     assert result.blocks
     assert "{{image_" not in result.content
@@ -110,63 +113,79 @@ async def test_news_article_fallback_preserves_nested_content_once(http_response
     response = http_response(
         "https://www.vlr.gg/1",
         b"""
-        <html><head><title>Fallback article</title></head><body><article>
-          <p>pre<a href="/player/1"><strong>bold<em>both</em></strong></a>post<br>next</p>
+        <article>
+          <header>
+            <h1>Fallback article</h1>
+            <div class="meta"><span class="author">by Author</span><time>2026-01-01</time></div>
+          </header>
+          <h2>Body heading</h2>
+          <p>Hello <strong>!</strong>
+            \xe2\x80\x9c <a href="/player/1"><strong>bold<em>both</em></strong></a> \xe2\x80\x9d joined;
+            <a href="/player/2">Player</a> 's match.<br>"<br><a href="/player/3">next</a>"
+            <a href="javascript:alert(1)">unsafe</a></p>
+          <p>First paragraph</p><p>! Second paragraph</p>
           <ol start="3"><li>Outer<ul><li>Inner</li></ul>Tail</li><li>Second</li></ol>
           <figure><a href="/photo"><img src="//owcdn.net/photo.jpg" alt="Winner"></a>
             <figcaption>Photo <em>credit</em></figcaption></figure>
-          <video><source src="/clip.mp4"></video><p>After video</p>
+          <a href="/clip"><video><source src="/clip.mp4"></video></a>
+          <img src="javascript:alert(2)"><p>After video</p>
           <script>hidden script</script><!-- hidden comment -->
-        </article></body></html>""",
+        </article>""",
     )
     with patch("httpx.AsyncClient.get", return_value=response):
         result = await news.news_by_id("1")
 
     assert result.title == "Fallback article"
-    assert [b.type for b in result.blocks] == ["paragraph", "list", "image", "caption", "video", "paragraph"]
-    paragraph, ordered, image, caption, video, _ = result.blocks
-    assert "".join(r.text for r in paragraph.runs) == "preboldbothpost\nnext"
+    assert result.author == "Author"
+    assert result.date is not None
+    assert [b.type for b in result.blocks] == [
+        "heading",
+        "paragraph",
+        "paragraph",
+        "paragraph",
+        "list",
+        "image",
+        "caption",
+        "video",
+        "paragraph",
+    ]
+    heading, paragraph, first, second, ordered, image, caption, video, after = result.blocks
+    assert "".join(r.text for r in heading.runs) == "Body heading"
+    assert heading.level == 2
+    assert "".join(r.text for r in paragraph.runs) == 'Hello! “boldboth” joined; Player\'s match.\n"\nnext" unsafe'
     linked = [r for r in paragraph.runs if r.url]
-    assert [(r.text, r.bold, r.italic) for r in linked] == [("bold", True, False), ("both", True, True)]
-    assert all(r.url == "https://www.vlr.gg/player/1" for r in linked)
+    assert [(r.text, r.bold, r.italic, r.url) for r in linked] == [
+        ("bold", True, False, "https://www.vlr.gg/player/1"),
+        ("both", True, True, "https://www.vlr.gg/player/1"),
+        ("Player", False, False, "https://www.vlr.gg/player/2"),
+        ("next", False, False, "https://www.vlr.gg/player/3"),
+    ]
+    assert "".join(r.text for r in first.runs) == "First paragraph"
+    assert "".join(r.text for r in second.runs) == "! Second paragraph"
     assert ordered.ordered and ordered.start == 3
     assert [b.type for b in ordered.children[0].children] == ["paragraph", "list", "paragraph"]
     assert len(ordered.children) == 2
-    assert image.url == "https://owcdn.net/photo.jpg" and image.alt == "Winner"
+    assert (image.url, image.link_url, image.alt) == (
+        "https://owcdn.net/photo.jpg",
+        "https://www.vlr.gg/photo",
+        "Winner",
+    )
     assert caption.runs[-1].italic
-    assert video.url == "https://www.vlr.gg/clip.mp4"
+    assert (video.url, video.link_url) == ("https://www.vlr.gg/clip.mp4", "https://www.vlr.gg/clip")
     assert video.player is None
-    assert result.content.count("After video") == 1
-    assert "hidden" not in result.content
-    assert result.links == [{"text": "boldboth", "url": "https://www.vlr.gg/player/1"}]
-
-
-@pytest.mark.asyncio
-async def test_news_video_links_only_embed_supported_providers(http_response):
-    accepted = [
-        "https://youtube.com/watch?v=vbBd_Hu6o2M",
-        "https://youtu.be/vbBd_Hu6o2M",
-        "https://www.youtube-nocookie.com/embed/vbBd_Hu6o2M",
-        "https://clips.twitch.tv/ExampleClip",
-        "https://www.twitch.tv/valorant/clip/ExampleClip",
+    assert "".join(r.text for r in after.runs) == "After video"
+    assert result.content == (
+        "Body heading\n\n"
+        'Hello! “{{link_0}}” joined; {{link_1}}\'s match.\n"\n{{link_2}}" unsafe\n\n'
+        "First paragraph\n\n! Second paragraph\n\n"
+        "3. Outer\n  \n  - Inner\n  \n  Tail\n4. Second\n\n"
+        "{image_0}\n\nPhoto credit\n\n{video_0}\n\nAfter video"
+    )
+    assert result.links == [
+        {"text": "boldboth", "url": "https://www.vlr.gg/player/1"},
+        {"text": "Player", "url": "https://www.vlr.gg/player/2"},
+        {"text": "next", "url": "https://www.vlr.gg/player/3"},
     ]
-    rejected = [
-        "https://youtube.com.evil.test/embed/vbBd_Hu6o2M",
-        "https://www.youtube.com/embed/invalid",
-        "https://clips.twitch.tv/embed?clip=%22%3E%3Cscript%3E",
-        "https://youtube.com@evil.test/embed/vbBd_Hu6o2M",
-    ]
-    html = "<article>" + "".join(f'<iframe src="{url}"></iframe>' for url in accepted + rejected) + "</article>"
-    with patch("httpx.AsyncClient.get", return_value=http_response("https://www.vlr.gg/1", html.encode())):
-        result = await news.news_by_id("1")
-    assert [b.player.provider if b.player else None for b in result.blocks] == [
-        "youtube",
-        "youtube",
-        "youtube",
-        "twitch",
-        "twitch",
-        None,
-        None,
-        None,
-        None,
-    ]
+    assert result.images == ["https://owcdn.net/photo.jpg"]
+    assert result.videos == ["https://www.vlr.gg/clip.mp4"]
+    assert "javascript:" not in result.model_dump_json()


### PR DESCRIPTION
News articles currently append media after all text and lose headings, emphasis, quotations, and list structure. This change preserves document order and supplies structured blocks that native clients can render without parsing HTML. Recognized YouTube videos and Twitch clips also receive player metadata and a hosted embed page for inline playback.

The existing content, links, images, and videos fields are generated from the same ordered blocks. Heading text, captions, nested lists, inline formatting, and links are retained without duplicate fallback extraction. Regression fixtures cover the Heretics photo placement, N4RRATE interview structure, and VARREL match-report headings.

Video blocks include provider, media ID, canonical external URL, and a relative player URL. The public `/media/{provider}/{media_id}` endpoint hosts only validated official YouTube and Twitch embeds, adds no dependencies, and requires no API credentials. The page sets the appropriate origin/referrer and Twitch parent, disables autoplay, and respects provider minimum dimensions. Deployment and client integration are documented in `docs/news-media.md`.

Validation:
- 38 offline backend tests passed, including provider validation and hosted-player HTTP contracts.
- Article golden snapshot includes the new response fields and was checked against downloaded live HTML; the article live test passed before the additive player metadata change.
- Ruff checks and formatting passed; targeted parser/schema type checks passed.
- Separate review found no remaining backend issues.
- Consumer changes were checked separately with 112 app tests, Android compilation, and an iOS build. Simulator checks covered previews, expanded player presentation, and retry fallback. App changes are outside this PR.

Actual provider playback remains to be verified after deployment. The live `/media/...` URL currently returns HTTP 403; the route must be publicly reachable over HTTPS, including through the reverse proxy.
